### PR TITLE
feat: Add sync-toolchains workflow

### DIFF
--- a/.github/workflows/sync-toolchains.yml
+++ b/.github/workflows/sync-toolchains.yml
@@ -25,6 +25,7 @@ jobs:
     strategy:
       matrix:
         dependant:
+          - zenoh
           - zenoh-c
           - zenoh-python
           - zenoh-java


### PR DESCRIPTION
This pull request adds a workflow that fetches the latest stable Rust release, and updates all eclipse-zenoh Rust toolchains to use it. The workflow is scheduled to run nightly.