### PR TITLE
fix: Convert `input.exclude-build` to JSON object

### DIFF
--- a/.github/workflows/build-crates-artifacts.yml
+++ b/.github/workflows/build-crates-artifacts.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        exclude: ${{ inputs.exclude-builds }}
+        exclude: ${{ fromJson(inputs.exclude-builds) }}
         build:
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
           - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04 }


### PR DESCRIPTION
Closes https://github.com/eclipse-zenoh/ci/issues/14.