### PR TITLE
fix: Incorrect script path in build-crates-standalone action

### DIFF
--- a/.github/workflows/release-crates-cargo.yml
+++ b/.github/workflows/release-crates-cargo.yml
@@ -1,4 +1,4 @@
-name: Publish crates (Cargo)
+name: Release crates (Cargo)
 
 on:
   workflow_call:

--- a/.github/workflows/release-crates-debian.yml
+++ b/.github/workflows/release-crates-debian.yml
@@ -1,4 +1,4 @@
-name: Publish crates (Debian)
+name: Release crates (Debian)
 
 on:
   workflow_call:

--- a/.github/workflows/release-crates-eclipse.yml
+++ b/.github/workflows/release-crates-eclipse.yml
@@ -1,4 +1,4 @@
-name: Publish crates (Eclipse)
+name: Release crates (Eclipse)
 
 on:
   workflow_call:

--- a/.github/workflows/release-crates-github.yml
+++ b/.github/workflows/release-crates-github.yml
@@ -1,4 +1,4 @@
-name: Publish crates (GitHub)
+name: Release crates (GitHub)
 
 on:
   workflow_call:

--- a/.github/workflows/release-crates-homebrew.yml
+++ b/.github/workflows/release-crates-homebrew.yml
@@ -1,4 +1,4 @@
-name: Publish crates (Homebrew)
+name: Release crates (Homebrew)
 
 on:
   workflow_call:

--- a/build-crates-standalone/action.yml
+++ b/build-crates-standalone/action.yml
@@ -20,4 +20,4 @@ outputs:
 
 runs:
   using: node20
-  main: ../dist/build-crates-artifacts-main.js
+  main: ../dist/build-crates-standalone-main.js


### PR DESCRIPTION
Resolves https://github.com/eclipse-zenoh/ci/issues/25 (follow-up fix).