### PR TITLE
fix(tag-crates): Set `version` input to undefined when unspecified

### DIFF
--- a/dist/tag-crates-main.js
+++ b/dist/tag-crates-main.js
@@ -82270,7 +82270,7 @@ function setup() {
     const interDepsPattern = lib_core.getInput("inter-deps-pattern", { required: true });
     const interDepsVersion = lib_core.getInput("inter-deps-version");
     return {
-        version,
+        version: version == "" ? undefined : version,
         liveRun: liveRun == "" ? false : lib_core.getBooleanInput("live-run"),
         dryRunHistorySize: dryRunHistorySize == "" ? undefined : Number(dryRunHistorySize),
         repo,

--- a/src/tag-crates.ts
+++ b/src/tag-crates.ts
@@ -33,7 +33,7 @@ export function setup(): Input {
   const interDepsVersion = core.getInput("inter-deps-version");
 
   return {
-    version,
+    version: version == "" ? undefined : version,
     liveRun: liveRun == "" ? false : core.getBooleanInput("live-run"),
     dryRunHistorySize: dryRunHistorySize == "" ? undefined : Number(dryRunHistorySize),
     repo,


### PR DESCRIPTION
Resolves https://github.com/eclipse-zenoh/ci/issues/31.