### PR TITLE
fix: Add default for `exclude-builds` in build-crates-standalone

### DIFF
--- a/.github/workflows/build-crates-standalone.yml
+++ b/.github/workflows/build-crates-standalone.yml
@@ -18,6 +18,7 @@ on:
       exclude-builds:
         type: string
         required: false
+        default: '[]'
   workflow_dispatch:
     inputs:
       repo:
@@ -35,6 +36,7 @@ on:
       exclude-builds:
         type: string
         required: false
+        default: '[]'
 
 jobs:
   build:


### PR DESCRIPTION
Fixes #38.