### PR TITLE
fix: Don't push the tag in `create-release-branch` action

### DIFF
--- a/dist/create-release-branch-main.js
+++ b/dist/create-release-branch-main.js
@@ -24827,7 +24827,7 @@ async function main(input) {
             }
         }
         sh(`git switch --create ${branch}`, { cwd: repo });
-        sh(`git push ${remote} ${branch} ${version}`, { cwd: repo });
+        sh(`git push ${remote} ${branch}`, { cwd: repo });
         await cleanup(input);
     }
     catch (error) {

--- a/src/create-release-branch.ts
+++ b/src/create-release-branch.ts
@@ -64,7 +64,7 @@ export async function main(input: Input) {
     }
 
     sh(`git switch --create ${branch}`, { cwd: repo });
-    sh(`git push ${remote} ${branch} ${version}`, { cwd: repo });
+    sh(`git push ${remote} ${branch}`, { cwd: repo });
 
     await cleanup(input);
   } catch (error) {


### PR DESCRIPTION
Resolves https://github.com/eclipse-zenoh/ci/issues/44.