### PR TITLE
fix: Get release version from branch step in `branch-tag-bump-crates`

### DIFF
--- a/.github/workflows/branch-bump-tag-crates.yml
+++ b/.github/workflows/branch-bump-tag-crates.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           repo: ${{ inputs.repo }}
           path: ${{ inputs.path }}
-          version: ${{ inputs.version }}
+          version: ${{ steps.create-release-branch.outputs.version }}
           bump-deps-pattern: ${{ inputs.bump-deps-pattern }}
           bump-deps-version: ${{ inputs.bump-deps-version }}
           bump-deps-branch: ${{ inputs.bump-deps-branch }}


### PR DESCRIPTION
Resolves https://github.com/eclipse-zenoh/ci/issues/44.