### PR TITLE
fix: Require `branch` input in `bump-crates` action metadata

### DIFF
--- a/.github/workflows/branch-bump-tag-crates.yml
+++ b/.github/workflows/branch-bump-tag-crates.yml
@@ -73,6 +73,7 @@ jobs:
           repo: ${{ inputs.repo }}
           path: ${{ inputs.path }}
           version: ${{ steps.create-release-branch.outputs.version }}
+          branch: ${{ steps.create-release-branch.outputs.branch }}
           bump-deps-pattern: ${{ inputs.bump-deps-pattern }}
           bump-deps-version: ${{ inputs.bump-deps-version }}
           bump-deps-branch: ${{ inputs.bump-deps-branch }}

--- a/bump-crates/action.yml
+++ b/bump-crates/action.yml
@@ -2,9 +2,9 @@ name: Bump crates
 
 inputs:
   version:
-    required: false
+    required: true
   branch:
-    required: false
+    required: true
   repo:
     required: true
   path:


### PR DESCRIPTION
Resolves https://github.com/eclipse-zenoh/ci/issues/44.