### PR TITLE
fix: Clone release branch in bump-crates action

### DIFF
--- a/dist/bump-crates-main.js
+++ b/dist/bump-crates-main.js
@@ -82299,7 +82299,7 @@ async function main(input) {
         const repo = input.repo.split("/")[1];
         const workspace = input.path === undefined ? repo : (0,external_path_.join)(repo, input.path);
         const remote = `https://${input.githubToken}@github.com/${input.repo}.git`;
-        command_sh(`git clone --recursive ${remote}`);
+        command_sh(`git clone --recursive --single-branch --branch ${input.branch} ${remote}`);
         command_sh(`ls ${workspace}`);
         await bump(workspace, input.version);
         command_sh("git add .", { cwd: repo });

--- a/src/bump-crates.ts
+++ b/src/bump-crates.ts
@@ -46,7 +46,7 @@ export async function main(input: Input) {
     const workspace = input.path === undefined ? repo : join(repo, input.path);
     const remote = `https://${input.githubToken}@github.com/${input.repo}.git`;
 
-    sh(`git clone --recursive ${remote}`);
+    sh(`git clone --recursive --single-branch --branch ${input.branch} ${remote}`);
     sh(`ls ${workspace}`);
 
     await cargo.bump(workspace, input.version);


### PR DESCRIPTION
Resolves https://github.com/eclipse-zenoh/ci/issues/44.