### PR TITLE
fix: Early exit in `bump-crates` action when tag exists

### DIFF
--- a/dist/bump-crates-main.js
+++ b/dist/bump-crates-main.js
@@ -82301,6 +82301,12 @@ async function main(input) {
         const remote = `https://${input.githubToken}@github.com/${input.repo}.git`;
         command_sh(`git clone --recursive --single-branch --branch ${input.branch} ${remote}`);
         command_sh(`ls ${workspace}`);
+        const tags = command_sh("git tag").split("\n");
+        if (tags.includes(input.version)) {
+            lib_core.info(`Tag ${input.version} has already been created`);
+            await cleanup(input);
+            return;
+        }
         await bump(workspace, input.version);
         command_sh("git add .", { cwd: repo });
         command_sh(`git commit --message 'chore: Bump version to \`${input.version}\`'`, { cwd: repo, env: gitEnv });

--- a/src/bump-crates.ts
+++ b/src/bump-crates.ts
@@ -49,6 +49,13 @@ export async function main(input: Input) {
     sh(`git clone --recursive --single-branch --branch ${input.branch} ${remote}`);
     sh(`ls ${workspace}`);
 
+    const tags = sh("git tag").split("\n");
+    if (tags.includes(input.version)) {
+      core.info(`Tag ${input.version} has already been created`);
+      await cleanup(input);
+      return;
+    }
+
     await cargo.bump(workspace, input.version);
     sh("git add .", { cwd: repo });
     sh(`git commit --message 'chore: Bump version to \`${input.version}\`'`, { cwd: repo, env: gitEnv });


### PR DESCRIPTION
Resolves https://github.com/eclipse-zenoh/ci/issues/44.