### PR TITLE
fix: Execute git-tag in repo in `bump-crates` actions

### DIFF
--- a/dist/bump-crates-main.js
+++ b/dist/bump-crates-main.js
@@ -82301,7 +82301,7 @@ async function main(input) {
         const remote = `https://${input.githubToken}@github.com/${input.repo}.git`;
         command_sh(`git clone --recursive --single-branch --branch ${input.branch} ${remote}`);
         command_sh(`ls ${workspace}`);
-        const tags = command_sh("git tag").split("\n");
+        const tags = command_sh("git tag", { cwd: repo }).split("\n");
         if (tags.includes(input.version)) {
             lib_core.info(`Tag ${input.version} has already been created`);
             await cleanup(input);

--- a/src/bump-crates.ts
+++ b/src/bump-crates.ts
@@ -49,7 +49,7 @@ export async function main(input: Input) {
     sh(`git clone --recursive --single-branch --branch ${input.branch} ${remote}`);
     sh(`ls ${workspace}`);
 
-    const tags = sh("git tag").split("\n");
+    const tags = sh("git tag", { cwd: repo }).split("\n");
     if (tags.includes(input.version)) {
       core.info(`Tag ${input.version} has already been created`);
       await cleanup(input);


### PR DESCRIPTION
Resolves #44.