### PR TITLE
fix: Maximize build space in publish-crates-cargo workflow

### DIFF
--- a/.github/workflows/release-crates-cargo.yml
+++ b/.github/workflows/release-crates-cargo.yml
@@ -40,6 +40,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - uses: easimon/maximize-build-space@master
+
       - uses: eclipse-zenoh/ci/publish-crates-cargo@main
         with:
           repo: ${{ inputs.repo }}


### PR DESCRIPTION
Resolves #44.

Building Zenoh in cargo-publish by itself takes more storage space than is available out of the box on GitHub-hosted runners.