### PR TITLE
fix: Run publish-crates-cargo on windows-latest

### DIFF
--- a/.github/workflows/release-crates-cargo.yml
+++ b/.github/workflows/release-crates-cargo.yml
@@ -38,10 +38,8 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
-      - uses: easimon/maximize-build-space@master
-
       - uses: eclipse-zenoh/ci/publish-crates-cargo@main
         with:
           repo: ${{ inputs.repo }}


### PR DESCRIPTION
As of today, `df -h` returns the following:

- On ubuntu-latest: 18G (:
- On macos-latest: 69G
- On windows-latest: 72G

The windows-latest runner has better specs than the macos-latest runner, hence the choice.

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories