### PR TITLE
fix: Don't run cargo-publish on Windows, use macOS

### DIFF
--- a/.github/workflows/release-crates-cargo.yml
+++ b/.github/workflows/release-crates-cargo.yml
@@ -38,7 +38,7 @@ on:
 
 jobs:
   publish:
-    runs-on: windows-latest
+    runs-on: macos-latest
     steps:
       - uses: eclipse-zenoh/ci/publish-crates-cargo@main
         with:


### PR DESCRIPTION
After #76, cargo-publish fails because zenoh-plugin-rest's build script changes the source directory (it's not supposed to) and that makes the publishing fail (LF is changed to CRLF). 

This changes release-crates-cargo to use macOS because even though the file will be rewritten, it will stay identical.

Again, we can't use Ubuntu because the storage space is too low.

See https://github.com/eclipse-zenoh/zenoh/issues/897.