### PR TITLE
fix: Allow dirty workspace in dry-run publishing

### DIFF
--- a/dist/publish-crates-cargo-main.js
+++ b/dist/publish-crates-cargo-main.js
@@ -82401,7 +82401,7 @@ async function publishToEstuary(input, repo, registry, registryDepsRegExp, branc
         CARGO_REGISTRY_DEFAULT: registry.name,
         [`CARGO_REGISTRIES_${registry.name.toUpperCase()}_TOKEN`]: registry.token,
     };
-    publish(path, env);
+    publish(path, env, true);
 }
 function publishToCratesIo(input, repo, branch) {
     clone(input, repo, branch);
@@ -82411,7 +82411,7 @@ function publishToCratesIo(input, repo, branch) {
     };
     publish(path, env);
 }
-function publish(path, env) {
+function publish(path, env, allowDirty = false) {
     const options = {
         env,
         cwd: path,
@@ -82419,7 +82419,11 @@ function publish(path, env) {
     };
     for (const package_ of packagesOrdered(path)) {
         if (package_.publish == undefined || package_.publish) {
-            command_sh(`cargo publish --manifest-path ${package_.manifestPath}`, options);
+            const command = ["cargo", "publish", "--manifest-path", package_.manifestPath];
+            if (allowDirty) {
+                command.push("--allow-dirty");
+            }
+            command_sh(command.join(" "), options);
         }
     }
     command_sh("cargo clean", options);

--- a/src/publish-crates-cargo.ts
+++ b/src/publish-crates-cargo.ts
@@ -122,7 +122,7 @@ async function publishToEstuary(
     [`CARGO_REGISTRIES_${registry.name.toUpperCase()}_TOKEN`]: registry.token,
   };
 
-  publish(path, env);
+  publish(path, env, true);
 }
 
 function publishToCratesIo(input: Input, repo: string, branch?: string) {
@@ -136,7 +136,7 @@ function publishToCratesIo(input: Input, repo: string, branch?: string) {
   publish(path, env);
 }
 
-function publish(path: string, env: NodeJS.ProcessEnv) {
+function publish(path: string, env: NodeJS.ProcessEnv, allowDirty: boolean = false) {
   const options = {
     env,
     cwd: path,
@@ -145,7 +145,11 @@ function publish(path: string, env: NodeJS.ProcessEnv) {
 
   for (const package_ of cargo.packagesOrdered(path)) {
     if (package_.publish == undefined || package_.publish) {
-      sh(`cargo publish --manifest-path ${package_.manifestPath}`, options);
+      const command = ["cargo", "publish", "--manifest-path", package_.manifestPath];
+      if (allowDirty) {
+        command.push("--allow-dirty");
+      }
+      sh(command.join(" "), options);
     }
   }
 


### PR DESCRIPTION
See https://github.com/eclipse-zenoh/zenoh-backend-filesystem/actions/runs/8551849755/job/23431732477.