### PR TITLE
feat: Add sync-lockfiles workflow

### DIFF
--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -1,0 +1,132 @@
+name: Sync Cargo lockfiles
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # At the end of every day
+  workflow_dispatch:
+    inputs:
+      branch:
+        type: string
+        description:
+          The branch to sync across all depedant repositories. Defaults to the default branch on each repository
+        required: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  fetch:
+    name: Fetch Zenoh's lockfile
+    runs-on: ubuntu-latest
+    outputs:
+      zenoh-head-hash: ${{ steps.info.outputs.head-hash }}
+      zenoh-head-date: ${{ steps.info.outputs.head-date }}
+    steps:
+      - name: Checkout Zenoh
+        uses: actions/checkout@v4
+        with:
+          repository: eclipse-zenoh/zenoh
+          ref: ${{ inputs.branch }}
+
+      - id: info
+        name: Get HEAD info
+        run: |
+          echo "head-hash=$(git log -1 --format=%h)" >> $GITHUB_OUTPUT
+          echo "head-date=$(git log -1 --format=%ah)" >> $GITHUB_OUTPUT
+
+      - name: Upload lockfile
+        uses: actions/upload-artifact@v3
+        with:
+          name: Cargo.lock
+          path: Cargo.lock
+
+  sync:
+    name: Sync Cargo lockfile with ${{ matrix.dependant }}
+    needs: fetch
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dependant:
+          - zenoh-c
+          - zenoh-python
+          - zenoh-java
+          - zenoh-kotlin
+          - zenoh-plugin-dds
+          - zenoh-plugin-mqtt
+          - zenoh-plugin-ros1
+          - zenoh-plugin-ros2dds
+          - zenoh-plugin-webserver
+          - zenoh-backend-filesystem
+          - zenoh-backend-influxdb
+          - zenoh-backend-rocksdb
+          - zenoh-backend-s3
+    steps:
+      - name: Checkout ${{ matrix.dependant }}
+        uses: actions/checkout@v4
+        with:
+          repository: eclipse-zenoh/${{ matrix.dependant }}
+          ref: ${{ inputs.branch }}
+          submodules: true
+          token: ${{ secrets.BOT_TOKEN_WORKFLOW }}
+
+      - name: Install Rust toolchain
+        # NOTE: Showing the active Rust toolchain (defined by the rust-toolchain.toml file)
+        # will have the side effect of installing it; if it's not installed already.
+        run: rustup show
+
+      # NOTE: Not all Zenoh dependants have their Cargo manifest and lockfile
+      # at the repository's toplevel. The only exception being zenoh-kotlin and
+      # zenoh-java. Thus the need for this ugly workaround.
+      - name: Compute crate path of ${{ matrix.dependant }}
+        id: crate-path
+        run: |
+          if [[ "${{ matrix.dependant }}" =~ zenoh-(java|kotlin) ]]; then
+            echo "value=zenoh-jni" >> $GITHUB_OUTPUT
+          else
+            echo "value=." >> $GITHUB_OUTPUT
+          fi
+
+      - name: Override ${{ matrix.dependant }} lockfile with Zenoh's
+        uses: actions/download-artifact@v3
+        with:
+          name: Cargo.lock
+          path: ${{ steps.crate-path.outputs.value }}
+
+      - name: Rectify lockfile
+        # NOTE: Checking the package for errors will rectify the Cargo.lock while preserving
+        # the dependency versions fetched from source.
+        run: cargo check --manifest-path ${{ steps.crate-path.outputs.value }}/Cargo.toml
+
+      - name: Create/Update a pull request if the lockfile changed
+        id: cpr
+        # NOTE: If there is a pending PR, this action will simply update it with a forced push.
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: Sync `Cargo.lock` with Zenoh `${{ needs.fetch.outputs.zenoh-head-hash }}` from `${{needs.fetch.outputs.zenoh-head-date }}`"
+          body: |
+            This pull request synchronizes ${{ matrix.dependant }}'s Cargo lockfile with Zenoh's.
+            This is done to ensure ABI compatibility between Zenoh applications, backends & plugins.
+
+            - **sha**: eclipse-zenoh/zenoh@${{ needs.fetch.outputs.zenoh-head-hash }}
+            - **date**: ${{ needs.fetch.outputs.zenoh-head-date }}
+            - **workflow**: [${{ github.run_id}}](https://github.com/eclipse-zenoh/zenoh/actions/runs/${{ github.run_id }})
+          commit-message: "build: Sync Cargo lockfile with Zenoh's"
+          committer: eclipse-zenoh-bot <eclipse-zenoh-bot@users.noreply.github.com>
+          author: eclipse-zenoh-bot <eclipse-zenoh-bot@users.noreply.github.com>
+          base: ${{ inputs.branch }}
+          branch: eclipse-zenoh-bot/sync-lockfile
+          delete-branch: true
+          labels: dependencies
+          token: ${{ secrets.BOT_TOKEN_WORKFLOW }}
+
+      - name: Enable auto merge for the pull request
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        run: >
+          gh pr merge "${{ steps.cpr.outputs.pull-request-number }}"
+          --subject "build: Sync `Cargo.lock` with eclipse-zenoh/zenoh@${{ needs.fetch.outputs.zenoh-head-hash }} from ${{ needs.fetch.outputs.zenoh-head-date }} (#${{ steps.cpr.outputs.pull-request-number }})"
+          --repo "eclipse-zenoh/${{ matrix.dependant }}"
+          --squash --auto
+        env:
+          GH_TOKEN: ${{ secrets.BOT_TOKEN_WORKFLOW }}


### PR DESCRIPTION
This moves the sync-lockfiles workflow from eclipse-zenoh/zenoh to eclipse-zenoh/ci.

Sister pull request: https://github.com/eclipse-zenoh/zenoh/pull/916.