### PR TITLE
fix: Incorrect `ssh-host-path` in release-crates-eclipse workflow

### DIFF
--- a/.github/workflows/release-crates-eclipse.yml
+++ b/.github/workflows/release-crates-eclipse.yml
@@ -78,6 +78,6 @@ jobs:
           live-run: ${{ inputs.live-run }}
           version: ${{ inputs.version }}
           ssh-host: genie.zenoh@projects-storage.eclipse.org
-          ssh-host-path: /home/data/httpd/download.eclipse.org/${{ inputs.name }}
+          ssh-host-path: /home/data/httpd/download.eclipse.org/zenoh/${{ inputs.name }}
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           ssh-passphrase: ${{ secrets.SSH_PASSPHRASE }}


### PR DESCRIPTION
This could've been bad 😮‍💨