### PR TITLE
fix: Use `git switch --force-create` to override existing branch

### DIFF
--- a/dist/create-release-branch-main.js
+++ b/dist/create-release-branch-main.js
@@ -24824,7 +24824,7 @@ async function main(input) {
         const branchExists = refs.includes(`refs/remotes/origin/${branch}`);
         if (branchExists) {
             core.info(`Release branch for ${version} already exists and will be updated`);
-            sh(`git switch ${branch}`, { cwd: repo });
+            sh(`git switch --force-create ${branch}`, { cwd: repo });
             sh(`git push --force ${remote} ${branch}`, { cwd: repo });
         }
         else {

--- a/src/create-release-branch.ts
+++ b/src/create-release-branch.ts
@@ -60,7 +60,7 @@ export async function main(input: Input) {
     const branchExists = refs.includes(`refs/remotes/origin/${branch}`);
     if (branchExists) {
       core.info(`Release branch for ${version} already exists and will be updated`);
-      sh(`git switch ${branch}`, { cwd: repo });
+      sh(`git switch --force-create ${branch}`, { cwd: repo });
       sh(`git push --force ${remote} ${branch}`, { cwd: repo });
     } else {
       sh(`git switch --create ${branch}`, { cwd: repo });


### PR DESCRIPTION
I've mistakenly used `git switch` to re-create the release branch from the default branch.