### PR TITLE
fix: Force push release branch in bump-crates

### DIFF
--- a/dist/bump-crates-main.js
+++ b/dist/bump-crates-main.js
@@ -82357,14 +82357,16 @@ async function main(input) {
                 check: false,
             });
         }
-        command_sh(`git push ${remote} ${input.branch}`, { cwd: repo });
         const tagExists = command_sh("git tag", { cwd: repo }).split("\n").includes(input.version);
         if (tagExists) {
             lib_core.info(`Tag ${input.version} already exists and will be replaced`);
+            // NOTE(fuzzypixelz): If the tag exists, then the branch exists too nad has to be pushed
+            command_sh(`git push --force ${remote} ${input.branch}`, { cwd: repo });
             command_sh(`git tag --force ${input.version} --message v${input.version}`, { cwd: repo, env: gitEnv });
             command_sh(`git push --force ${remote} ${input.version}`, { cwd: repo });
         }
         else {
+            command_sh(`git push ${remote} ${input.branch}`, { cwd: repo });
             command_sh(`git tag ${input.version} --message v${input.version}`, { cwd: repo, env: gitEnv });
             command_sh(`git push ${remote} ${input.version}`, { cwd: repo });
         }

--- a/src/bump-crates.ts
+++ b/src/bump-crates.ts
@@ -70,14 +70,15 @@ export async function main(input: Input) {
       });
     }
 
-    sh(`git push ${remote} ${input.branch}`, { cwd: repo });
-
     const tagExists = sh("git tag", { cwd: repo }).split("\n").includes(input.version);
     if (tagExists) {
       core.info(`Tag ${input.version} already exists and will be replaced`);
+      // NOTE(fuzzypixelz): If the tag exists, then the branch exists too nad has to be pushed
+      sh(`git push --force ${remote} ${input.branch}`, { cwd: repo });
       sh(`git tag --force ${input.version} --message v${input.version}`, { cwd: repo, env: gitEnv });
       sh(`git push --force ${remote} ${input.version}`, { cwd: repo });
     } else {
+      sh(`git push ${remote} ${input.branch}`, { cwd: repo });
       sh(`git tag ${input.version} --message v${input.version}`, { cwd: repo, env: gitEnv });
       sh(`git push ${remote} ${input.version}`, { cwd: repo });
     }


### PR DESCRIPTION
This only happens when the release tag and by extension the release branch already exist.