### PR TITLE
fix: Always force push release branch and tag

### DIFF
--- a/dist/bump-crates-main.js
+++ b/dist/bump-crates-main.js
@@ -82357,19 +82357,12 @@ async function main(input) {
                 check: false,
             });
         }
-        const tagExists = command_sh("git tag", { cwd: repo }).split("\n").includes(input.version);
-        if (tagExists) {
+        if (command_sh("git tag", { cwd: repo }).split("\n").includes(input.version)) {
             lib_core.info(`Tag ${input.version} already exists and will be replaced`);
-            // NOTE(fuzzypixelz): If the tag exists, then the branch exists too nad has to be pushed
-            command_sh(`git push --force ${remote} ${input.branch}`, { cwd: repo });
-            command_sh(`git tag --force ${input.version} --message v${input.version}`, { cwd: repo, env: gitEnv });
-            command_sh(`git push --force ${remote} ${input.version}`, { cwd: repo });
         }
-        else {
-            command_sh(`git push ${remote} ${input.branch}`, { cwd: repo });
-            command_sh(`git tag ${input.version} --message v${input.version}`, { cwd: repo, env: gitEnv });
-            command_sh(`git push ${remote} ${input.version}`, { cwd: repo });
-        }
+        command_sh(`git push --force ${remote} ${input.branch}`, { cwd: repo });
+        command_sh(`git tag --force ${input.version} --message v${input.version}`, { cwd: repo, env: gitEnv });
+        command_sh(`git push --force ${remote} ${input.version}`, { cwd: repo });
         command_sh("git log -10", { cwd: repo });
         command_sh("git show-ref --tags", { cwd: repo });
         await cleanup(input);

--- a/src/bump-crates.ts
+++ b/src/bump-crates.ts
@@ -70,18 +70,13 @@ export async function main(input: Input) {
       });
     }
 
-    const tagExists = sh("git tag", { cwd: repo }).split("\n").includes(input.version);
-    if (tagExists) {
+    if (sh("git tag", { cwd: repo }).split("\n").includes(input.version)) {
       core.info(`Tag ${input.version} already exists and will be replaced`);
-      // NOTE(fuzzypixelz): If the tag exists, then the branch exists too nad has to be pushed
-      sh(`git push --force ${remote} ${input.branch}`, { cwd: repo });
-      sh(`git tag --force ${input.version} --message v${input.version}`, { cwd: repo, env: gitEnv });
-      sh(`git push --force ${remote} ${input.version}`, { cwd: repo });
-    } else {
-      sh(`git push ${remote} ${input.branch}`, { cwd: repo });
-      sh(`git tag ${input.version} --message v${input.version}`, { cwd: repo, env: gitEnv });
-      sh(`git push ${remote} ${input.version}`, { cwd: repo });
     }
+
+    sh(`git push --force ${remote} ${input.branch}`, { cwd: repo });
+    sh(`git tag --force ${input.version} --message v${input.version}`, { cwd: repo, env: gitEnv });
+    sh(`git push --force ${remote} ${input.version}`, { cwd: repo });
 
     sh("git log -10", { cwd: repo });
     sh("git show-ref --tags", { cwd: repo });


### PR DESCRIPTION
It's simpler to force push every time, because throughout the code we don't fetch tags. Something to fix in the future.