### PR TITLE
fix: Remove unecessary ssh passphrase/private-key in publish-crates-github

### DIFF
--- a/.github/workflows/release-crates-github.yml
+++ b/.github/workflows/release-crates-github.yml
@@ -82,6 +82,4 @@ jobs:
           live-run: ${{ inputs.live-run }}
           version: ${{ inputs.version }}
           branch: ${{ inputs.branch }}
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-passphrase: ${{ secrets.SSH_PASSPHRASE }}
           github-token: ${{ secrets.BOT_TOKEN_WORKFLOW }}

--- a/publish-crates-github/action.yml
+++ b/publish-crates-github/action.yml
@@ -9,10 +9,6 @@ inputs:
     required: true
   branch:
     required: true
-  ssh-private-key:
-    required: true
-  ssh-passphrase:
-    required: true
   github-token:
     required: true
   archive-patterns:

--- a/src/publish-crates-github.ts
+++ b/src/publish-crates-github.ts
@@ -14,8 +14,6 @@ export type Input = {
   repo: string;
   version: string;
   branch: string;
-  sshPrivateKey: string;
-  sshPassphrase: string;
   githubToken: string;
   archiveRegExp?: RegExp;
 };
@@ -25,8 +23,6 @@ export function setup(): Input {
   const repo = core.getInput("repo", { required: true });
   const version = core.getInput("version", { required: true });
   const branch = core.getInput("branch", { required: true });
-  const sshPrivateKey = core.getInput("ssh-private-key", { required: true });
-  const sshPassphrase = core.getInput("ssh-passphrase", { required: true });
   const githubToken = core.getInput("github-token", { required: true });
   const archivePatterns = core.getInput("archive-patterns", { required: false });
 
@@ -35,8 +31,6 @@ export function setup(): Input {
     version,
     branch,
     repo,
-    sshPrivateKey,
-    sshPassphrase,
     githubToken,
     archiveRegExp: archivePatterns == "" ? undefined : new RegExp(archivePatterns.split("\n").join("|")),
   };


### PR DESCRIPTION
This was a copy-pasting error most likely.