### PR TITLE
fix: Use latest GitHub release tag as starting tag

### DIFF
--- a/src/publish-crates-github.ts
+++ b/src/publish-crates-github.ts
@@ -46,16 +46,18 @@ export async function main(input: Input) {
     const releaseTags = JSON.parse(releaseTagsRaw) as GitHubRelease[];
     // NOTE: We use compute the latest release (or pre-release) and use its tag name as the starting
     // tag for the next release.
-    const startTag = releaseTags.at(0).tagName;
+    const latestRelease = releaseTags.at(0);
 
     if (input.liveRun) {
-      sh(
-        `gh release create ${input.version} \
-        --repo ${input.repo} \
-        --target ${input.branch} \
-        --notes-start-tag ${startTag} --verify-tag --generate-notes`,
-        { env },
-      );
+      const command = ["gh", "release", "create"];
+      command.push("--repo", input.repo);
+      command.push("--target", input.branch);
+      command.push("--verify-tag");
+      command.push("--generate-notes");
+      if (latestRelease != undefined) {
+        command.push("--notes-start-tag", latestRelease.tagName);
+      }
+      sh(command.join(" "), { env });
     }
 
     const shouldPublishArtifact = (name: string): boolean => {


### PR DESCRIPTION
Previously we just assumed that if the caller wants to release version `V`, then the repository should contains a tag `V-dev`. But this is very brittle and won't work for repositories that can't have `*-dev` versions like zenoh-c, zenoh-cpp and zenoh-pico (thanks CMake).