### PR TITLE
fix: Add missing tag input in gh-release-create

### DIFF
--- a/src/publish-crates-github.ts
+++ b/src/publish-crates-github.ts
@@ -50,7 +50,7 @@ export async function main(input: Input) {
     const releaseLatest = releases.at(0);
 
     if (input.liveRun) {
-      const command = ["gh", "release", "create"];
+      const command = ["gh", "release", "create", input.version];
       command.push("--repo", input.repo);
       command.push("--target", input.branch);
       command.push("--verify-tag");


### PR DESCRIPTION
In #104 I mistakenly removed the tag from the command.