### PR TITLE
fix: Kill estuary during live-runs in publish-crates-cargo

### DIFF
--- a/dist/publish-crates-cargo-main.js
+++ b/dist/publish-crates-cargo-main.js
@@ -81344,13 +81344,13 @@ function setup() {
         branch,
         repo,
         githubToken,
-        unpublishedDepsRegExp: unpublishedDepsPatterns == "" ? /^$/ : new RegExp(unpublishedDepsPatterns.split("\n").join("|")),
-        unpublishedDepsRepos: unpublishedDepsRepos == "" ? [] : unpublishedDepsRepos.split("\n"),
+        unpublishedDepsRegExp: unpublishedDepsPatterns === "" ? /^$/ : new RegExp(unpublishedDepsPatterns.split("\n").join("|")),
+        unpublishedDepsRepos: unpublishedDepsRepos === "" ? [] : unpublishedDepsRepos.split("\n"),
         cratesIoToken,
     };
 }
 async function main(input) {
-    let registry;
+    let registry = undefined;
     try {
         registry = await _estuary__WEBPACK_IMPORTED_MODULE_2__/* .spawn */ .C();
         for (const repo of input.unpublishedDepsRepos) {
@@ -81373,7 +81373,7 @@ async function main(input) {
     }
 }
 async function cleanup(input, registry) {
-    if (!input.liveRun) {
+    if (registry !== undefined) {
         _actions_core__WEBPACK_IMPORTED_MODULE_1__.info(`Killing estuary process (${registry.proc.pid})`);
         try {
             process.kill(registry.proc.pid);
@@ -81388,7 +81388,7 @@ async function cleanup(input, registry) {
 }
 function clone(input, repo, branch) {
     const remote = `https://${input.githubToken}@github.com/${repo}.git`;
-    if (branch == undefined) {
+    if (branch === undefined) {
         (0,_command__WEBPACK_IMPORTED_MODULE_4__.sh)(`git clone --recursive ${remote}`);
     }
     else {
@@ -81432,7 +81432,7 @@ function publish(path, env, allowDirty = false) {
         check: true,
     };
     for (const package_ of _cargo__WEBPACK_IMPORTED_MODULE_3__/* .packagesOrdered */ .r4(path)) {
-        if (package_.publish == undefined || package_.publish) {
+        if (package_.publish === undefined || package_.publish) {
             const command = ["cargo", "publish", "--manifest-path", package_.manifestPath];
             if (allowDirty) {
                 command.push("--allow-dirty");

--- a/src/publish-crates-cargo.ts
+++ b/src/publish-crates-cargo.ts
@@ -31,14 +31,14 @@ export function setup(): Input {
     repo,
     githubToken,
     unpublishedDepsRegExp:
-      unpublishedDepsPatterns == "" ? /^$/ : new RegExp(unpublishedDepsPatterns.split("\n").join("|")),
-    unpublishedDepsRepos: unpublishedDepsRepos == "" ? [] : unpublishedDepsRepos.split("\n"),
+      unpublishedDepsPatterns === "" ? /^$/ : new RegExp(unpublishedDepsPatterns.split("\n").join("|")),
+    unpublishedDepsRepos: unpublishedDepsRepos === "" ? [] : unpublishedDepsRepos.split("\n"),
     cratesIoToken,
   };
 }
 
 export async function main(input: Input) {
-  let registry: estuary.Estuary;
+  let registry: estuary.Estuary = undefined;
   try {
     registry = await estuary.spawn();
 
@@ -65,8 +65,8 @@ export async function main(input: Input) {
   }
 }
 
-export async function cleanup(input: Input, registry: estuary.Estuary) {
-  if (!input.liveRun) {
+export async function cleanup(input: Input, registry?: estuary.Estuary) {
+  if (registry !== undefined) {
     core.info(`Killing estuary process (${registry.proc.pid})`);
     try {
       process.kill(registry.proc.pid);
@@ -83,7 +83,7 @@ export async function cleanup(input: Input, registry: estuary.Estuary) {
 function clone(input: Input, repo: string, branch?: string): void {
   const remote = `https://${input.githubToken}@github.com/${repo}.git`;
 
-  if (branch == undefined) {
+  if (branch === undefined) {
     sh(`git clone --recursive ${remote}`);
   } else {
     sh(`git clone --recursive --single-branch --branch ${branch} ${remote}`);
@@ -144,7 +144,7 @@ function publish(path: string, env: NodeJS.ProcessEnv, allowDirty: boolean = fal
   };
 
   for (const package_ of cargo.packagesOrdered(path)) {
-    if (package_.publish == undefined || package_.publish) {
+    if (package_.publish === undefined || package_.publish) {
       const command = ["cargo", "publish", "--manifest-path", package_.manifestPath];
       if (allowDirty) {
         command.push("--allow-dirty");


### PR DESCRIPTION
Estuary should be killed in both live-runs and dry-runs.