### PR TITLE
fix: Pass `BINARY` build-arg in publish-crates-docker action

### DIFF
--- a/publish-crates-docker/action.yml
+++ b/publish-crates-docker/action.yml
@@ -74,6 +74,8 @@ runs:
         platforms: ${{ inputs.platforms }}
         push: ${{ inputs.live-run }}
         tags: ${{ inputs.tags }}
+        build-args: |
+          BINARY=${{ inputs.binary }}
         labels: |
           org.opencontainers.image.source=https://github.com/${{ inputs.repo }}
           org.opencontainers.image.licenses=${{ inputs.licenses }}


### PR DESCRIPTION
Fixes https://github.com/eclipse-zenoh/ci/issues/121.