### PR TITLE
Add repo as input for publish debian action

### DIFF
--- a/.github/workflows/release-crates-debian.yml
+++ b/.github/workflows/release-crates-debian.yml
@@ -70,3 +70,4 @@ jobs:
           ssh-host-path: /home/data/httpd/download.eclipse.org/zenoh/debian-repo
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           ssh-passphrase: ${{ secrets.SSH_PASSPHRASE }}
+          repo: ${{ inputs.repo }}

--- a/publish-crates-debian/action.yml
+++ b/publish-crates-debian/action.yml
@@ -15,6 +15,8 @@ inputs:
     required: true
   installation-test:
     required: true
+  repo:
+    required: true
 
 runs:
   using: node20

--- a/src/publish-crates-debian.ts
+++ b/src/publish-crates-debian.ts
@@ -23,6 +23,7 @@ export type Input = {
   sshPrivateKey: string;
   sshPassphrase: string;
   installationTest: boolean;
+  repo: string;
 };
 
 export function setup(): Input {
@@ -33,6 +34,7 @@ export function setup(): Input {
   const sshPrivateKey = core.getInput("ssh-private-key", { required: true });
   const sshPassphrase = core.getInput("ssh-passphrase", { required: true });
   const installationTest = core.getBooleanInput("installation-test", { required: true });
+  const repo = core.getInput("repo", {required: true});
 
   return {
     liveRun,
@@ -42,6 +44,7 @@ export function setup(): Input {
     sshPrivateKey,
     sshPassphrase,
     installationTest,
+    repo,
   };
 }
 
@@ -69,7 +72,7 @@ export async function main(input: Input) {
     }
 
     const debianRepo = `${input.sshHost}:${input.sshHostPath}`;
-    const packagesPath = `.Packages-${input.version}`;
+    const packagesPath = `.Packages-${input.repo}-${input.version}`;
     const allPackagesPath = "Packages";
     const allPackagesGzippedPath = "Packages.gz";
 


### PR DESCRIPTION
We now include the repo as part of the temporary
.Packages-$repo-$version file used to generate Packages.gz for the debian repository. This way the temporary .Packages file is not overwritten per package when the action runs causing Packages.gz to be built with missing Packages.

Fix #130 