### PR TITLE
fix: Pull before push in publish-crates-homebrew

### DIFF
--- a/src/publish-crates-homebrew.ts
+++ b/src/publish-crates-homebrew.ts
@@ -128,6 +128,7 @@ export async function main(input: Input) {
     }
 
     if (input.liveRun) {
+      sh(`git pull ${tapUrl} --rebase`, { cwd: tapPath });
       sh(`git push ${tapUrl}`, { cwd: tapPath });
     }
 


### PR DESCRIPTION
Workflows that use the publish-crates-homebrew in parallel may cause conflicts when cloning/pushing. This is a workaround, ultimately the homebrew tap should pull changes from download.eclipse.org instead.