### PR TITLE
fix: typo in docker publish action

### DIFF
--- a/publish-crates-docker/action.yml
+++ b/publish-crates-docker/action.yml
@@ -74,7 +74,7 @@ runs:
         platforms: ${{ inputs.platforms }}
         push: true
         tags: |
-          ${{ inputs.image }}:${{ version }}
+          ${{ inputs.image }}:${{ inputs.version }}
           ${{ inputs.image }}:${{ inputs.live-run == 'true' && 'latest' || 'nightly' }}
         build-args: |
           BINARY=${{ inputs.binary }}


### PR DESCRIPTION
Use inputs.version instead of version as that's the proper way. Fix failure like this: https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/actions/runs/8982804657/job/24671959155