### PR TITLE
fix: update check-labels.yml to use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - run: gh pr view ${{ github.event.pull_request.number }} --json labels --repo ${{ github.repository }} | jq -e '.labels != []'
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN_WORKFLOW }}
+          GH_TOKEN: ${{ github.token}}


### PR DESCRIPTION
Secrets are not automatically passed to reusable workflows from forked repos, but `github.token` is available and should be enough to perform the pr check.