### PR TITLE
feat: Add PR templates with pre-filled labels

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug.yml
+++ b/.github/PULL_REQUEST_TEMPLATE/bug.yml
@@ -1,0 +1,13 @@
+name: Bug
+description: |
+  Pull request proposing a fix to a bug.
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: "Describe the pull request"
+      description: |
+        A clear and concise description of the changes.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE/enhancement.yml
+++ b/.github/PULL_REQUEST_TEMPLATE/enhancement.yml
@@ -1,0 +1,13 @@
+name: Enhancement
+description: |
+  Pull request proposing an enhancement.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: "Describe the pull request"
+      description: |
+        A clear and concise description of the changes.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE/internal.yml
+++ b/.github/PULL_REQUEST_TEMPLATE/internal.yml
@@ -1,0 +1,13 @@
+name: Internal
+description: |
+  Pull request proposing an internal change that shouldn't show up in the changelog.
+labels: ["internal"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: "Describe the pull request"
+      description: |
+        A clear and concise description of the changes.
+    validations:
+      required: true


### PR DESCRIPTION
Contributors can't label their own PRs in the `eclipse-zenoh` org. This PR attempts to facilitate the process by providing PR templates with pre-filled labels so contributors can submit PRs using those.