### PR TITLE
fix: use branch name instead of full refname

### DIFF
--- a/dist/create-release-branch-main.js
+++ b/dist/create-release-branch-main.js
@@ -24851,7 +24851,11 @@ async function main(input) {
             branch = `release/dry-run/${version}`;
             lib_core.setOutput("branch", branch);
             const refsPattern = "refs/remotes/origin/release/dry-run";
-            const refsRaw = sh(`git for-each-ref --format='%(refname)' --sort=authordate ${refsPattern}`, { cwd: repo });
+            // for some reason using the full refname won't work to delete the remote branch, so
+            // refname:strip=3 removes 'refs/remotes/origin' from the pattern to have the branch name only.
+            const refsRaw = sh(`git for-each-ref --format='%(refname:strip=3)' --sort=authordate ${refsPattern}`, {
+                cwd: repo,
+            });
             const refs = refsRaw.split("\n");
             if (refs.length >= input.dryRunHistorySize) {
                 const toDelete = refs.slice(0, refs.length - input.dryRunHistorySize);

--- a/src/create-release-branch.ts
+++ b/src/create-release-branch.ts
@@ -49,7 +49,11 @@ export async function main(input: Input) {
       core.setOutput("branch", branch);
 
       const refsPattern = "refs/remotes/origin/release/dry-run";
-      const refsRaw = sh(`git for-each-ref --format='%(refname)' --sort=authordate ${refsPattern}`, { cwd: repo });
+      // for some reason using the full refname won't work to delete the remote branch, so
+      // refname:strip=3 removes 'refs/remotes/origin' from the pattern to have the branch name only.
+      const refsRaw = sh(`git for-each-ref --format='%(refname:strip=3)' --sort=authordate ${refsPattern}`, {
+        cwd: repo,
+      });
       const refs = refsRaw.split("\n");
 
       if (refs.length >= input.dryRunHistorySize) {


### PR DESCRIPTION
Using `git push origin --delete refname`  apparently doesn't delete remote branch, so we strip the parts from the refname to get only the branch name. Fix #142 for real this time.