### PR TITLE
fix: Remove `schedule` event trigger in sync-toolchains workflow

### DIFF
--- a/.github/workflows/sync-toolchains.yml
+++ b/.github/workflows/sync-toolchains.yml
@@ -1,8 +1,6 @@
 name: Sync Rust toolchains
 
 on:
-  schedule:
-    - cron: "0 0 * * *" # At the end of every day
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
This was mistakenly included in #3.