### PR TITLE
fix: Empty `branch` input in `create-release-branch`

### DIFF
--- a/dist/create-release-branch-main.js
+++ b/dist/create-release-branch-main.js
@@ -24851,7 +24851,7 @@ function setup() {
         version: version === "" ? undefined : version,
         liveRun,
         repo,
-        branch,
+        branch: branch === "" ? undefined : branch,
         githubToken,
         dryRunHistorySize: dryRunHistorySize == "" ? DEFAULT_DRY_RUN_HISTORY_SIZE : Number(dryRunHistorySize),
     };

--- a/src/create-release-branch.ts
+++ b/src/create-release-branch.ts
@@ -28,7 +28,7 @@ export function setup(): Input {
     version: version === "" ? undefined : version,
     liveRun,
     repo,
-    branch,
+    branch: branch === "" ? undefined : branch,
     githubToken,
     dryRunHistorySize: dryRunHistorySize == "" ? DEFAULT_DRY_RUN_HISTORY_SIZE : Number(dryRunHistorySize),
   };


### PR DESCRIPTION
See https://github.com/eclipse-zenoh/zenoh/actions/runs/9539833719/job/26290670848.