### PR TITLE
fix: publication-test shouldn't be required

### DIFF
--- a/.github/workflows/release-crates-cargo.yml
+++ b/.github/workflows/release-crates-cargo.yml
@@ -20,7 +20,7 @@ on:
         required: false
       publication-test:
         type: boolean
-        required: true
+        required: false
         default: false
   workflow_dispatch:
     inputs:
@@ -41,7 +41,7 @@ on:
         required: false
       publication-test:
         type: boolean
-        required: true
+        required: false
         default: false
 
 jobs:

--- a/dist/publish-crates-cargo-main.js
+++ b/dist/publish-crates-cargo-main.js
@@ -81358,7 +81358,7 @@ function setup() {
     const cratesIoToken = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput("crates-io-token", { required: true });
     const unpublishedDepsPatterns = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput("unpublished-deps-patterns");
     const unpublishedDepsRepos = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput("unpublished-deps-repos");
-    const publicationTest = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getBooleanInput("publication-test", { required: true });
+    const publicationTest = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getBooleanInput("publication-test");
     return {
         liveRun,
         branch,

--- a/publish-crates-cargo/action.yml
+++ b/publish-crates-cargo/action.yml
@@ -16,7 +16,7 @@ inputs:
   unpublished-deps-repos:
     required: false
   publication-test:
-    required: true
+    required: false
 
 runs:
   using: node20

--- a/src/publish-crates-cargo.ts
+++ b/src/publish-crates-cargo.ts
@@ -25,7 +25,7 @@ export function setup(): Input {
   const cratesIoToken = core.getInput("crates-io-token", { required: true });
   const unpublishedDepsPatterns = core.getInput("unpublished-deps-patterns");
   const unpublishedDepsRepos = core.getInput("unpublished-deps-repos");
-  const publicationTest = core.getBooleanInput("publication-test", { required: true });
+  const publicationTest = core.getBooleanInput("publication-test");
 
   return {
     liveRun,


### PR DESCRIPTION
that way we don't need to update all the zenoh-* repos workflows