### PR TITLE
Revert "fix: re-enable cargo publication test"

### DIFF
--- a/.github/workflows/release-crates-cargo.yml
+++ b/.github/workflows/release-crates-cargo.yml
@@ -21,7 +21,7 @@ on:
       publication-test:
         type: boolean
         required: false
-        default: true
+        default: false
   workflow_dispatch:
     inputs:
       repo:
@@ -42,7 +42,7 @@ on:
       publication-test:
         type: boolean
         required: false
-        default: true
+        default: false
 
 jobs:
   publish:


### PR DESCRIPTION
This reverts commit 207d35f1f1156a52251da54539f9eb77d82c2859.