### PR TITLE
fix: Update workflow to use macos-12

### DIFF
--- a/.github/workflows/build-crates-standalone.yml
+++ b/.github/workflows/build-crates-standalone.yml
@@ -53,8 +53,8 @@ jobs:
           - { target: armv7-unknown-linux-gnueabihf, os: ubuntu-20.04 }
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04 }
           - { target: aarch64-unknown-linux-musl, os: ubuntu-20.04 }
-          - { target: x86_64-apple-darwin, os: macos-11 }
-          - { target: aarch64-apple-darwin, os: macos-11 }
+          - { target: x86_64-apple-darwin, os: macos-12 }
+          - { target: aarch64-apple-darwin, os: macos-12 }
           - { target: x86_64-pc-windows-msvc, os: windows-2019 }
           - { target: x86_64-pc-windows-gnu, os: windows-2019 }
     steps:


### PR DESCRIPTION
macos-11 has been officially deprecated by github