### PR TITLE
Don't sync zenoh-[java,kotlin]

### DIFF
--- a/.github/workflows/sync-lockfiles-1.0.0.yml
+++ b/.github/workflows/sync-lockfiles-1.0.0.yml
@@ -52,8 +52,6 @@ jobs:
         dependant:
           - zenoh-c
           - zenoh-python
-          - zenoh-java
-          - zenoh-kotlin
           - zenoh-plugin-dds
           - zenoh-plugin-mqtt
           - zenoh-plugin-ros1
@@ -63,6 +61,9 @@ jobs:
           - zenoh-backend-influxdb
           - zenoh-backend-rocksdb
           - zenoh-backend-s3
+          # zenoh-[java,kotlin] are not ready yet for 1.0.0
+          #- zenoh-java
+          #- zenoh-kotlin
     steps:
       - name: Checkout ${{ matrix.dependant }}
         uses: actions/checkout@v4


### PR DESCRIPTION
They are not ready yet to be released with 1.0.0