### PR TITLE
fix: don't fail workflow if tag delete fails

### DIFF
--- a/dist/create-release-branch-main.js
+++ b/dist/create-release-branch-main.js
@@ -24883,7 +24883,8 @@ async function main(input) {
                 toDelete.forEach(branch => {
                     const tag = branch.replace("release/dry-run/", "");
                     command_sh(`git push origin --delete ${branch}`, { cwd: repo });
-                    command_sh(`git push origin --delete ${tag}`, { cwd: repo });
+                    // Don't fail the entire workflow if the tag delete fails
+                    command_sh(`git push origin --delete ${tag}`, { cwd: repo, check: false });
                 });
             }
         }

--- a/src/create-release-branch.ts
+++ b/src/create-release-branch.ts
@@ -65,7 +65,8 @@ export async function main(input: Input) {
         toDelete.forEach(branch => {
           const tag = branch.replace("release/dry-run/", "");
           sh(`git push origin --delete ${branch}`, { cwd: repo });
-          sh(`git push origin --delete ${tag}`, { cwd: repo });
+          // Don't fail the entire workflow if the tag delete fails
+          sh(`git push origin --delete ${tag}`, { cwd: repo, check: false });
         });
       }
     }


### PR DESCRIPTION
Example failure: https://github.com/eclipse-zenoh/zenoh-python/actions/runs/9692165123/job/26744971281