### PR TITLE
fix: Update sync lock files script for zenoh-c

### DIFF
--- a/.github/workflows/sync-lockfiles-1.0.0.yml
+++ b/.github/workflows/sync-lockfiles-1.0.0.yml
@@ -96,6 +96,14 @@ jobs:
           name: Cargo.lock
           path: ${{ steps.crate-path.outputs.value }}
 
+      # Another ugly workaround, since zenoh-c has an additional Cargo.lock not in the root
+      - name: Override ${{ matrix.dependant }} build-resources lockfile with Zenoh's
+        if: ${{ matrix.dependant }} == "zenoh-c"
+        uses: actions/download-artifact@v4
+        with:
+          name: Cargo.lock
+          path: build-resources/opaque-types/Cargo.lock
+
       - name: Rectify lockfile
         # NOTE: Checking the package for errors will rectify the Cargo.lock while preserving
         # the dependency versions fetched from source.


### PR DESCRIPTION
zenoh-c has an additional Cargo.lock file in
build-resources/opaque-types/Cargo.lock that needs to be synced as well.

Fix #201