### PR TITLE
fix: don't delete tag while removing branches

### DIFF
--- a/dist/create-release-branch-main.js
+++ b/dist/create-release-branch-main.js
@@ -24881,10 +24881,7 @@ async function main(input) {
             if (branches.length >= input.dryRunHistorySize) {
                 const toDelete = branches.slice(0, branches.length - input.dryRunHistorySize);
                 toDelete.forEach(branch => {
-                    const tag = branch.replace("release/dry-run/", "");
                     command_sh(`git push origin --delete ${branch}`, { cwd: repo });
-                    // Don't fail the entire workflow if the tag delete fails
-                    command_sh(`git push origin --delete ${tag}`, { cwd: repo, check: false });
                 });
             }
         }

--- a/src/create-release-branch.ts
+++ b/src/create-release-branch.ts
@@ -63,10 +63,7 @@ export async function main(input: Input) {
       if (branches.length >= input.dryRunHistorySize) {
         const toDelete = branches.slice(0, branches.length - input.dryRunHistorySize);
         toDelete.forEach(branch => {
-          const tag = branch.replace("release/dry-run/", "");
           sh(`git push origin --delete ${branch}`, { cwd: repo });
-          // Don't fail the entire workflow if the tag delete fails
-          sh(`git push origin --delete ${tag}`, { cwd: repo, check: false });
         });
       }
     }


### PR DESCRIPTION
During dry-run, the code ended up deleting the latest released tag.

See https://github.com/eclipse-zenoh/zenoh/actions/runs/10268819316/job/28412756096

