### PR TITLE
fix: scheduled sync-lockfile for 1.0.0 workflow

### DIFF
--- a/.github/workflows/sync-lockfiles-1.0.0.yml
+++ b/.github/workflows/sync-lockfiles-1.0.0.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: eclipse-zenoh/zenoh
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || 'dev/1.0.0' }}
 
       - id: info
         name: Get HEAD info
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: eclipse-zenoh/${{ matrix.dependant }}
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || 'dev/1.0.0' }}
           submodules: true
           token: ${{ secrets.BOT_TOKEN_WORKFLOW }}
 
@@ -124,7 +124,7 @@ jobs:
           commit-message: "build: Sync Cargo lockfile with Zenoh's"
           committer: eclipse-zenoh-bot <eclipse-zenoh-bot@users.noreply.github.com>
           author: eclipse-zenoh-bot <eclipse-zenoh-bot@users.noreply.github.com>
-          base: ${{ inputs.branch }}
+          base: ${{ inputs.branch || 'dev/1.0.0' }}
           branch: eclipse-zenoh-bot/sync-lockfile
           delete-branch: true
           labels: dependencies


### PR DESCRIPTION
Default inputs for scheduled workflow are not taken into account, so this fix guarantees we always use the dev/1.0.0 on scheduled runs.