### PR TITLE
fix: use shell to build Packages file

### DIFF
--- a/src/publish-crates-debian.ts
+++ b/src/publish-crates-debian.ts
@@ -48,18 +48,6 @@ export function setup(): Input {
   };
 }
 
-function gzip(input: string): Promise<Buffer> {
-  return new Promise((resolve, reject) => {
-    zlib.gzip(input, { level: 9 }, (error, buffer) => {
-      if (!error) {
-        resolve(buffer);
-      } else {
-        reject(error);
-      }
-    });
-  });
-}
-
 export async function main(input: Input) {
   try {
     const results = await artifact.listArtifacts({ latest: true });

--- a/src/publish-crates-debian.ts
+++ b/src/publish-crates-debian.ts
@@ -88,9 +88,8 @@ export async function main(input: Input) {
     await fs.writeFile(packagesPath, sh(`dpkg-scanpackages --multiversion ${input.version}`));
     // NOTE: An unzipped package index is necessary for apt-get to recognize the
     // local repository created below
-    const packages = sh(`cat .Packages-*`, { quiet: true });
-    await fs.writeFile(allPackagesPath, packages);
-    await fs.writeFile(allPackagesGzippedPath, await gzip(packages));
+    sh(`cat .Packages-* > ${allPackagesPath}`, { quiet: true });
+    sh(`gzip -k ${allPackagesPath}`, { quiet: true });
 
     sh("ls -R");
     core.info(`Adding a local Debian repository at ${process.cwd()}`);

--- a/src/publish-crates-debian.ts
+++ b/src/publish-crates-debian.ts
@@ -77,7 +77,7 @@ export async function main(input: Input) {
     // NOTE: An unzipped package index is necessary for apt-get to recognize the
     // local repository created below
     sh(`cat .Packages-* > ${allPackagesPath}`, { quiet: true });
-    sh(`gzip -k ${allPackagesPath}`, { quiet: true });
+    sh(`gzip -k -9 ${allPackagesPath}`, { quiet: true });
 
     sh("ls -R");
     core.info(`Adding a local Debian repository at ${process.cwd()}`);

--- a/src/publish-crates-debian.ts
+++ b/src/publish-crates-debian.ts
@@ -1,5 +1,4 @@
 import * as fs from "fs/promises";
-import * as zlib from "zlib";
 
 import * as core from "@actions/core";
 import { DefaultArtifactClient } from "@actions/artifact";


### PR DESCRIPTION
attempt to fix error during publication of debian package

See https://github.com/eclipse-zenoh/zenoh-plugin-ros1/actions/runs/10852956160/job/30120604711