### PR TITLE
fix: install build dependencies

### DIFF
--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -76,6 +76,9 @@ jobs:
         # will have the side effect of installing it; if it's not installed already.
         run: rustup show
 
+      - name: Install build dependencies
+        run: apt install llvm-dev libclang-dev clang
+
       # NOTE: Not all Zenoh dependants have their Cargo manifest and lockfile
       # at the repository's toplevel. The only exception being zenoh-kotlin and
       # zenoh-java. Thus the need for this ugly workaround.


### PR DESCRIPTION
so cargo clippy can build everything to rectify the lock file

 Try to avoid these errors: 
Cargo.lock sync failure [zenoh-plugin-dds](https://github.com/eclipse-zenoh/ci/actions/runs/10937948277/job/30364972553)
 Cargo.lock sync failure [zenoh-plugin-ros2dds](https://github.com/eclipse-zenoh/ci/actions/runs/10937948277/job/30364973604)