### PR TITLE
chore: update build-crates runners to use win2019

### DIFF
--- a/.github/workflows/build-crates-standalone.yml
+++ b/.github/workflows/build-crates-standalone.yml
@@ -55,8 +55,8 @@ jobs:
           - { target: aarch64-unknown-linux-musl, os: ubuntu-20.04 }
           - { target: x86_64-apple-darwin, os: macos-12 }
           - { target: aarch64-apple-darwin, os: macos-12 }
-          - { target: x86_64-pc-windows-msvc, os: windows-2019 }
-          - { target: x86_64-pc-windows-gnu, os: windows-2019 }
+          - { target: x86_64-pc-windows-msvc, os: windows-2022 }
+          - { target: x86_64-pc-windows-gnu, os: windows-2022 }
     steps:
       - id: build
         uses: eclipse-zenoh/ci/build-crates-standalone@main

--- a/.github/workflows/build-crates-standalone.yml
+++ b/.github/workflows/build-crates-standalone.yml
@@ -55,9 +55,18 @@ jobs:
           - { target: aarch64-unknown-linux-musl, os: ubuntu-20.04 }
           - { target: x86_64-apple-darwin, os: macos-12 }
           - { target: aarch64-apple-darwin, os: macos-12 }
-          - { target: x86_64-pc-windows-msvc, os: windows-2022 }
-          - { target: x86_64-pc-windows-gnu, os: windows-2022 }
+          - { target: x86_64-pc-windows-msvc, os: windows-2019 }
+          - { target: x86_64-pc-windows-gnu, os: windows-2019 }
     steps:
+      # Fix the version due to the issue: https://github.com/egor-tensin/setup-mingw/issues/17#issuecomment-1890253793
+      - uses: ilammy/setup-nasm@v1
+        if: ${{ matrix.build.os == 'windows-2019' }}
+      - name: Set up MinGW
+        if: ${{ matrix.build.os == 'windows-2019' }}
+        uses: egor-tensin/setup-mingw@v2.2.0
+        with:
+          version: 12.2.0
+
       - id: build
         uses: eclipse-zenoh/ci/build-crates-standalone@main
         with:


### PR DESCRIPTION
A newer version of windows is required to be able to build zenoh-plugin-mqtt. See https://github.com/evshary/zenoh-plugin-mqtt/actions/runs/11008828853/job/30567221247 