### PR TITLE
Don't tag dry-run releases

### DIFF
--- a/.github/workflows/branch-bump-tag-crates.yml
+++ b/.github/workflows/branch-bump-tag-crates.yml
@@ -78,6 +78,7 @@ jobs:
       - uses: eclipse-zenoh/ci/bump-crates@main
         with:
           repo: ${{ inputs.repo }}
+          live-run: ${{ inputs.live-run }}
           path: ${{ inputs.path }}
           version: ${{ steps.create-release-branch.outputs.version }}
           branch: ${{ steps.create-release-branch.outputs.branch }}

--- a/bump-crates/action.yml
+++ b/bump-crates/action.yml
@@ -3,6 +3,8 @@ name: Bump crates
 inputs:
   version:
     required: true
+  live-run:
+    required: false
   branch:
     required: true
   repo:

--- a/dist/bump-crates-main.js
+++ b/dist/bump-crates-main.js
@@ -81103,6 +81103,7 @@ _cargo__WEBPACK_IMPORTED_MODULE_4__ = (__webpack_async_dependencies__.then ? (aw
 
 function setup() {
     const version = _actions_core__WEBPACK_IMPORTED_MODULE_2__.getInput("version", { required: true });
+    const liveRun = _actions_core__WEBPACK_IMPORTED_MODULE_2__.getBooleanInput("live-run", { required: true });
     const branch = _actions_core__WEBPACK_IMPORTED_MODULE_2__.getInput("branch", { required: true });
     const repo = _actions_core__WEBPACK_IMPORTED_MODULE_2__.getInput("repo", { required: true });
     const path = _actions_core__WEBPACK_IMPORTED_MODULE_2__.getInput("path");
@@ -81112,6 +81113,7 @@ function setup() {
     const bumpDepsBranch = _actions_core__WEBPACK_IMPORTED_MODULE_2__.getInput("bump-deps-branch");
     return {
         version,
+        liveRun,
         branch,
         repo,
         path: path === "" ? undefined : path,
@@ -81147,8 +81149,10 @@ async function main(input) {
             });
         }
         (0,_command__WEBPACK_IMPORTED_MODULE_3__.sh)(`git push --force ${remote} ${input.branch}`, { cwd: repo });
-        (0,_command__WEBPACK_IMPORTED_MODULE_3__.sh)(`git tag --force ${input.version} --message v${input.version}`, { cwd: repo, env: _config__WEBPACK_IMPORTED_MODULE_5__/* .gitEnv */ .B });
-        (0,_command__WEBPACK_IMPORTED_MODULE_3__.sh)(`git push --force ${remote} ${input.version}`, { cwd: repo });
+        if (input.liveRun) {
+            (0,_command__WEBPACK_IMPORTED_MODULE_3__.sh)(`git tag --force ${input.version} --message v${input.version}`, { cwd: repo, env: _config__WEBPACK_IMPORTED_MODULE_5__/* .gitEnv */ .B });
+            (0,_command__WEBPACK_IMPORTED_MODULE_3__.sh)(`git push --force ${remote} ${input.version}`, { cwd: repo });
+        }
         (0,_command__WEBPACK_IMPORTED_MODULE_3__.sh)("git log -10", { cwd: repo });
         (0,_command__WEBPACK_IMPORTED_MODULE_3__.sh)("git show-ref --tags", { cwd: repo });
         await cleanup(input);

--- a/src/bump-crates.ts
+++ b/src/bump-crates.ts
@@ -9,6 +9,7 @@ import { gitEnv } from "./config";
 
 export type Input = {
   version: string;
+  liveRun: boolean;
   branch: string;
   repo: string;
   path?: string;
@@ -20,6 +21,7 @@ export type Input = {
 
 export function setup(): Input {
   const version = core.getInput("version", { required: true });
+  const liveRun = core.getBooleanInput("live-run", { required: true });
   const branch = core.getInput("branch", { required: true });
   const repo = core.getInput("repo", { required: true });
   const path = core.getInput("path");
@@ -30,6 +32,7 @@ export function setup(): Input {
 
   return {
     version,
+    liveRun,
     branch,
     repo,
     path: path === "" ? undefined : path,
@@ -71,8 +74,11 @@ export async function main(input: Input) {
     }
 
     sh(`git push --force ${remote} ${input.branch}`, { cwd: repo });
-    sh(`git tag --force ${input.version} --message v${input.version}`, { cwd: repo, env: gitEnv });
-    sh(`git push --force ${remote} ${input.version}`, { cwd: repo });
+
+    if (input.liveRun) {
+      sh(`git tag --force ${input.version} --message v${input.version}`, { cwd: repo, env: gitEnv });
+      sh(`git push --force ${remote} ${input.version}`, { cwd: repo });
+    }
 
     sh("git log -10", { cwd: repo });
     sh("git show-ref --tags", { cwd: repo });


### PR DESCRIPTION
This breaks the eclipse-zenoh/zenoh release workflow. Bindings have their own bump-and-tag.bash scripts which would need to updated individually.