### PR TITLE
Fix zenoh-dissector syncing

### DIFF
--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -81,6 +81,14 @@ jobs:
       - name: Install build dependencies
         run: sudo apt-get install -y llvm-dev libclang-dev clang libacl1-dev
 
+      - name: Install build dependencies (zenoh-dissector)
+        if: ${{ matrix.dependant == 'eclipse-zenoh/zenoh-dissector' }}
+        run: |
+          sudo apt install -y software-properties-common
+          sudo add-apt-repository -y ppa:wireshark-dev/stable
+          sudo apt install -y wireshark-dev
+          sudo apt install -y --allow-change-held-packages wireshark
+
       # NOTE: Not all Zenoh dependants have their Cargo manifest and lockfile
       # at the repository's toplevel. The only exception being zenoh-kotlin and
       # zenoh-java. Thus the need for this ugly workaround.

--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -62,8 +62,8 @@ jobs:
           - eclipse-zenoh/zenoh-backend-influxdb
           - eclipse-zenoh/zenoh-backend-rocksdb
           - eclipse-zenoh/zenoh-backend-s3
-          - ZettaScaleLabs/zenoh-dissector
           - eclipse-zenoh/zenoh-ts
+          - eclipse-zenoh/zenoh-dissector
     steps:
       - name: Checkout ${{ matrix.dependant }}
         uses: actions/checkout@v4
@@ -117,6 +117,7 @@ jobs:
           cargo clippy --manifest-path build-resources/opaque-types/Cargo.toml --all-targets --features $features -- --deny warnings
 
       - name: cargo update ${{ matrix.dependant }}
+        if: ${{ matrix.dependant != 'eclipse-zenoh/zenoh-dissector' }}
         run: cargo update zenoh --manifest-path ${{ steps.crate-path.outputs.value }}/Cargo.toml
 
       - name: cargo update for zenoh-c build-resources


### PR DESCRIPTION
zenoh-dissector has been moved to https://github.com/eclipse-zenoh/zenoh-dissector. In any case, the old workflow didn't have the necessary permissions to commit on the previous org.