### PR TITLE
chore: update to latest macos-14 runner

### DIFF
--- a/.github/workflows/build-crates-standalone.yml
+++ b/.github/workflows/build-crates-standalone.yml
@@ -53,8 +53,8 @@ jobs:
           - { target: armv7-unknown-linux-gnueabihf, os: ubuntu-20.04 }
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04 }
           - { target: aarch64-unknown-linux-musl, os: ubuntu-20.04 }
-          - { target: x86_64-apple-darwin, os: macos-12 }
-          - { target: aarch64-apple-darwin, os: macos-12 }
+          - { target: x86_64-apple-darwin, os: macos-14 }
+          - { target: aarch64-apple-darwin, os: macos-14 }
           - { target: x86_64-pc-windows-msvc, os: windows-2019 }
           - { target: x86_64-pc-windows-gnu, os: windows-2019 }
     steps:


### PR DESCRIPTION
macos-12 is being deprecated. See https://github.com/actions/runner-images/issues/10721