### PR TITLE
fix: shorten sync job name

### DIFF
--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -42,7 +42,7 @@ jobs:
           path: Cargo.lock
 
   sync:
-    name: ${{ matrix.dependant }}
+    name: ${{ matrix.dependant }} sync Cargo.lock
     needs: fetch
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -42,7 +42,7 @@ jobs:
           path: Cargo.lock
 
   sync:
-    name: Sync Cargo lockfile with ${{ matrix.dependant }}
+    name: ${{ matrix.dependant }}
     needs: fetch
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Using short name makes it easier to read in the github web ui