### PR TITLE
chore: update secrets variable names

### DIFF
--- a/.github/workflows/release-crates-debian.yml
+++ b/.github/workflows/release-crates-debian.yml
@@ -68,6 +68,6 @@ jobs:
           installation-test: ${{ inputs.installation-test }}
           ssh-host: genie.zenoh@projects-storage.eclipse.org
           ssh-host-path: /home/data/httpd/download.eclipse.org/zenoh/debian-repo
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-passphrase: ${{ secrets.SSH_PASSPHRASE }}
+          ssh-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
+          ssh-passphrase: ${{ secrets.ORG_GPG_PASSPHRASE }}
           repo: ${{ inputs.repo }}

--- a/.github/workflows/release-crates-eclipse.yml
+++ b/.github/workflows/release-crates-eclipse.yml
@@ -88,5 +88,5 @@ jobs:
           version: ${{ inputs.version }}
           ssh-host: genie.zenoh@projects-storage.eclipse.org
           ssh-host-path: /home/data/httpd/download.eclipse.org/zenoh/${{ inputs.name }}
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-passphrase: ${{ secrets.SSH_PASSPHRASE }}
+          ssh-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
+          ssh-passphrase: ${{ secrets.ORG_GPG_PASSPHRASE }}

--- a/.github/workflows/release-crates-homebrew.yml
+++ b/.github/workflows/release-crates-homebrew.yml
@@ -83,6 +83,6 @@ jobs:
           ssh-host: genie.zenoh@projects-storage.eclipse.org
           ssh-host-path: /home/data/httpd/download.eclipse.org/zenoh/homebrew-tap
           ssh-host-url: https://download.eclipse.org/zenoh/homebrew-tap
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-passphrase: ${{ secrets.SSH_PASSPHRASE }}
+          ssh-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
+          ssh-passphrase: ${{ secrets.ORG_GPG_PASSPHRASE }}
           github-token: ${{ secrets.BOT_TOKEN_WORKFLOW }}


### PR DESCRIPTION
As per https://github.com/eclipse-zenoh/.eclipsefdn/pull/18, secrets were updated to follow eclipse foundation naming convention.