### PR TITLE
Revert "chore: update secrets variable names"

### DIFF
--- a/.github/workflows/release-crates-debian.yml
+++ b/.github/workflows/release-crates-debian.yml
@@ -68,6 +68,6 @@ jobs:
           installation-test: ${{ inputs.installation-test }}
           ssh-host: genie.zenoh@projects-storage.eclipse.org
           ssh-host-path: /home/data/httpd/download.eclipse.org/zenoh/debian-repo
-          ssh-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
-          ssh-passphrase: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-passphrase: ${{ secrets.SSH_PASSPHRASE }}
           repo: ${{ inputs.repo }}

--- a/.github/workflows/release-crates-eclipse.yml
+++ b/.github/workflows/release-crates-eclipse.yml
@@ -88,5 +88,5 @@ jobs:
           version: ${{ inputs.version }}
           ssh-host: genie.zenoh@projects-storage.eclipse.org
           ssh-host-path: /home/data/httpd/download.eclipse.org/zenoh/${{ inputs.name }}
-          ssh-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
-          ssh-passphrase: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-passphrase: ${{ secrets.SSH_PASSPHRASE }}

--- a/.github/workflows/release-crates-homebrew.yml
+++ b/.github/workflows/release-crates-homebrew.yml
@@ -83,6 +83,6 @@ jobs:
           ssh-host: genie.zenoh@projects-storage.eclipse.org
           ssh-host-path: /home/data/httpd/download.eclipse.org/zenoh/homebrew-tap
           ssh-host-url: https://download.eclipse.org/zenoh/homebrew-tap
-          ssh-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
-          ssh-passphrase: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-passphrase: ${{ secrets.SSH_PASSPHRASE }}
           github-token: ${{ secrets.BOT_TOKEN_WORKFLOW }}


### PR DESCRIPTION
Reverts eclipse-zenoh/ci#247

In https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5255#note_2858788 I requested the values to be reinstated so we are able to make the release on the 21st