### PR TITLE
chore: remove zenoh-plugin-ros1 from sync lock

### DIFF
--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -55,7 +55,6 @@ jobs:
           - eclipse-zenoh/zenoh-kotlin
           - eclipse-zenoh/zenoh-plugin-dds
           - eclipse-zenoh/zenoh-plugin-mqtt
-          - eclipse-zenoh/zenoh-plugin-ros1
           - eclipse-zenoh/zenoh-plugin-ros2dds
           - eclipse-zenoh/zenoh-plugin-webserver
           - eclipse-zenoh/zenoh-backend-filesystem


### PR DESCRIPTION
zenoh-plugin-ros1 is deprecated and won't be released with newer zenoh versions (>=1.0.0)