### PR TITLE
fix: better debug message

### DIFF
--- a/.github/workflows/merge-release-branch.yml
+++ b/.github/workflows/merge-release-branch.yml
@@ -91,8 +91,9 @@ jobs:
           --base main \
           --label internal \
           -R ${{ matrix.repo }} \
-          2>&1) || exit_code=$?
-          echo $output
+          2>&1)
+          exit_code=$?
+          echo "Exit code: ${exit_code} Output: ${output}"
           if [[ ${exit_code} == 0 ]]; then
             echo "pull-request-operation=created" >> $GITHUB_OUTPUT
             pr_number="${output##*/pull/}"


### PR DESCRIPTION
Always capture the exit_code

Tries to fix error in annotating the PR after the creation step