### PR TITLE
fix: capture exit_code either way

### DIFF
--- a/.github/workflows/merge-release-branch.yml
+++ b/.github/workflows/merge-release-branch.yml
@@ -91,8 +91,7 @@ jobs:
           --base main \
           --label internal \
           -R ${{ matrix.repo }} \
-          2>&1)
-          exit_code=$?
+          2>&1) && exit_code=$? || exit_code=$?
           echo "Exit code: ${exit_code} Output: ${output}"
           if [[ ${exit_code} == 0 ]]; then
             echo "pull-request-operation=created" >> $GITHUB_OUTPUT


### PR DESCRIPTION
- when gh pr create succeeds, we want to set the exit_code=0 
- if it fails, we want to set it to exit_code=1 but not fail the step