### PR TITLE
fix: set bump-deps-version to same as version

### DIFF
--- a/dist/bump-crates-main.js
+++ b/dist/bump-crates-main.js
@@ -81119,7 +81119,7 @@ function setup() {
         path: path === "" ? undefined : path,
         githubToken,
         bumpDepsRegExp: bumpDepsPattern === "" ? undefined : new RegExp(bumpDepsPattern),
-        bumpDepsVersion: bumpDepsVersion === "" ? undefined : bumpDepsVersion,
+        bumpDepsVersion: bumpDepsVersion === "" ? version : bumpDepsVersion,
         bumpDepsBranch: bumpDepsBranch === "" ? undefined : bumpDepsBranch,
     };
 }

--- a/src/bump-crates.ts
+++ b/src/bump-crates.ts
@@ -38,7 +38,7 @@ export function setup(): Input {
     path: path === "" ? undefined : path,
     githubToken,
     bumpDepsRegExp: bumpDepsPattern === "" ? undefined : new RegExp(bumpDepsPattern),
-    bumpDepsVersion: bumpDepsVersion === "" ? undefined : bumpDepsVersion,
+    bumpDepsVersion: bumpDepsVersion === "" ? version : bumpDepsVersion,
     bumpDepsBranch: bumpDepsBranch === "" ? undefined : bumpDepsBranch,
   };
 }


### PR DESCRIPTION
bump-deps-version is nil because it can't have default values in scheduled events. Set it to same as version in this case.