### PR TITLE
fix: use windows-2022 runner

### DIFF
--- a/.github/workflows/build-crates-standalone.yml
+++ b/.github/workflows/build-crates-standalone.yml
@@ -55,8 +55,8 @@ jobs:
           - { target: aarch64-unknown-linux-musl, os: ubuntu-24.04 }
           - { target: x86_64-apple-darwin, os: macos-14 }
           - { target: aarch64-apple-darwin, os: macos-14 }
-          - { target: x86_64-pc-windows-msvc, os: windows-2019 }
-          - { target: x86_64-pc-windows-gnu, os: windows-2019 }
+          - { target: x86_64-pc-windows-msvc, os: windows-2022}
+          - { target: x86_64-pc-windows-gnu, os: windows-2022}
     steps:
       - id: build
         uses: eclipse-zenoh/ci/build-crates-standalone@main


### PR DESCRIPTION
windows-2022 runner still uses cmake 3.11 for now, and will unblock the 1.3.1 release for zenoh-plugin-ros2dds