### PR TITLE
fix: toml.get() should return falsy value

### DIFF
--- a/dist/build-crates-debian-main.mjs
+++ b/dist/build-crates-debian-main.mjs
@@ -102495,7 +102495,7 @@ var TOML = class _TOML {
     if (out) {
       return JSON.parse(out);
     } else {
-      return {};
+      return null;
     }
   }
   async set(path2, key, value) {

--- a/dist/build-crates-standalone-main.mjs
+++ b/dist/build-crates-standalone-main.mjs
@@ -102494,7 +102494,7 @@ var TOML = class _TOML {
     if (out) {
       return JSON.parse(out);
     } else {
-      return {};
+      return null;
     }
   }
   async set(path2, key, value) {

--- a/dist/bump-crates-main.mjs
+++ b/dist/bump-crates-main.mjs
@@ -63458,7 +63458,7 @@ var TOML = class _TOML {
     if (out) {
       return JSON.parse(out);
     } else {
-      return {};
+      return null;
     }
   }
   async set(path, key, value) {

--- a/dist/publish-crates-cargo-main.mjs
+++ b/dist/publish-crates-cargo-main.mjs
@@ -63459,7 +63459,7 @@ var TOML = class _TOML {
     if (out) {
       return JSON.parse(out);
     } else {
-      return {};
+      return null;
     }
   }
   async set(path, key, value) {

--- a/dist/publish-crates-debian-main.mjs
+++ b/dist/publish-crates-debian-main.mjs
@@ -102522,7 +102522,7 @@ var TOML = class _TOML {
     if (out) {
       return JSON.parse(out);
     } else {
-      return {};
+      return null;
     }
   }
   async set(path2, key, value) {

--- a/dist/publish-crates-eclipse-main.mjs
+++ b/dist/publish-crates-eclipse-main.mjs
@@ -102519,7 +102519,7 @@ var TOML = class _TOML {
     if (out) {
       return JSON.parse(out);
     } else {
-      return {};
+      return null;
     }
   }
   async set(path2, key, value) {

--- a/dist/publish-crates-github-main.mjs
+++ b/dist/publish-crates-github-main.mjs
@@ -102499,7 +102499,7 @@ var TOML = class _TOML {
     if (out) {
       return JSON.parse(out);
     } else {
-      return {};
+      return null;
     }
   }
   async set(path2, key, value) {

--- a/dist/publish-crates-homebrew-main.mjs
+++ b/dist/publish-crates-homebrew-main.mjs
@@ -102526,7 +102526,7 @@ var TOML = class _TOML {
     if (out) {
       return JSON.parse(out);
     } else {
-      return {};
+      return null;
     }
   }
   async set(path, key, value) {

--- a/dist/set-git-branch-main.mjs
+++ b/dist/set-git-branch-main.mjs
@@ -63458,7 +63458,7 @@ var TOML = class _TOML {
     if (out) {
       return JSON.parse(out);
     } else {
-      return {};
+      return null;
     }
   }
   async set(path, key, value) {

--- a/src/toml.ts
+++ b/src/toml.ts
@@ -15,7 +15,8 @@ export class TOML {
     if (out) {
       return JSON.parse(out) as Record<string, unknown>;
     } else {
-      return {};
+      // return falsy value while keeping the return type
+      return null as unknown as Record<string, unknown>;
     }
   }
 


### PR DESCRIPTION
this way toml.get() can be used in boolean contexts

See https://github.com/eclipse-zenoh/ci/actions/runs/14259663835/job/39968446406#step:4:199, when toml.get() is used in a boolean context returning {}, it evaluates to true which is not what we expect.