### PR TITLE
fix: merge main into post-release branch

### DIFF
--- a/.github/workflows/merge-release-branch.yml
+++ b/.github/workflows/merge-release-branch.yml
@@ -22,7 +22,7 @@ defaults:
 
 jobs:
   merge-release-branch:
-    name: Submit PR to merge release branch into main
+    name: ${{ matrix.repo }} PR to merge release branch into main
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/dist/set-git-branch-main.mjs
+++ b/dist/set-git-branch-main.mjs
@@ -63608,6 +63608,7 @@ async function main(input) {
         }
       }
     }
+    sh("git merge -Xours origin/main", { cwd: repo, env: gitEnv });
     sh(`git push --force ${remote} eclipse-zenoh-bot/post-release-${input.version}`, { cwd: repo });
     await cleanup(input);
   } catch (error) {

--- a/src/set-git-branch.ts
+++ b/src/set-git-branch.ts
@@ -82,6 +82,8 @@ export async function main(input: Input) {
         }
       }
     }
+    // Avoid Cargo.lock conflicts by merging the main branch into the post-release branch keeping our changes.
+    sh("git merge -Xours origin/main", { cwd: repo, env: gitEnv });
 
     sh(`git push --force ${remote} eclipse-zenoh-bot/post-release-${input.version}`, { cwd: repo });
 


### PR DESCRIPTION
This avoid merging conflicts if the Cargo.lock changed before the merge-release-branch workflow is executed after release. We keep our changes to update the Cargo.lock to the main branch.