### PR TITLE
fix: skip setup of rust 1.75 for zenoh-dissector

### DIFF
--- a/.github/workflows/merge-release-branch.yml
+++ b/.github/workflows/merge-release-branch.yml
@@ -47,7 +47,7 @@ jobs:
           - eclipse-zenoh/zenoh-dissector
     steps:
       - name: Setup rust toolchain
-        if: ${{ !contains(fromJSON('["eclipse-zenoh/zenoh", "eclipse-zenoh/zenoh-pico", "eclipse-zenoh/zenoh-cpp"]'), matrix.repo) }}
+        if: ${{ !contains(fromJSON('["eclipse-zenoh/zenoh", "eclipse-zenoh/zenoh-pico", "eclipse-zenoh/zenoh-cpp", "eclipse-zenoh/zenoh-dissector"]'), matrix.repo) }}
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.75.0


### PR DESCRIPTION
Fix https://github.com/eclipse-zenoh/ci/actions/runs/14263671373/job/39980629158