### PR TITLE
fix: keep branch input in create-release-branch

### DIFF
--- a/create-release-branch/action.yml
+++ b/create-release-branch/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
   repo:
     required: true
-  branch-or-hash:
+  branch:
     required: false
   github-token:
     required: true

--- a/dist/create-release-branch-main.mjs
+++ b/dist/create-release-branch-main.mjs
@@ -20017,7 +20017,7 @@ function setup() {
   const liveRun = core2.getBooleanInput("live-run", { required: true });
   const dryRunHistorySize = core2.getInput("dry-run-history-size", { required: false });
   const repo = core2.getInput("repo", { required: true });
-  const branchOrHash = core2.getInput("branch-or-hash", { required: false });
+  const branchOrHash = core2.getInput("branch", { required: false });
   const githubToken = core2.getInput("github-token", { required: true });
   return {
     version: version === "" ? void 0 : version,

--- a/dist/set-registry-main.mjs
+++ b/dist/set-registry-main.mjs
@@ -63501,10 +63501,10 @@ var ci_config_default = {
 // src/config.ts
 var config = ci_config_default;
 var gitEnv = {
-  GIT_AUTHOR_NAME: config.git.user.name,
-  GIT_AUTHOR_EMAIL: config.git.user.email,
-  GIT_COMMITTER_NAME: config.git.user.name,
-  GIT_COMMITTER_EMAIL: config.git.user.email
+  GIT_AUTHOR_NAME: process.env.GITHUB_AUTHOR_NAME || config.git.user.name,
+  GIT_AUTHOR_EMAIL: process.env.GITHUB_AUTHOR_EMAIL || config.git.user.email,
+  GIT_COMMITTER_NAME: process.env.GITHUB_AUTHOR_NAME || config.git.user.name,
+  GIT_COMMITTER_EMAIL: process.env.GITHUB_AUTHOR_EMAIL || config.git.user.email
 };
 
 // src/cargo.ts

--- a/src/create-release-branch.ts
+++ b/src/create-release-branch.ts
@@ -23,7 +23,8 @@ export function setup(): Input {
   const liveRun = core.getBooleanInput("live-run", { required: true });
   const dryRunHistorySize = core.getInput("dry-run-history-size", { required: false });
   const repo = core.getInput("repo", { required: true });
-  const branchOrHash = core.getInput("branch-or-hash", { required: false });
+  // To avoid breaking existing workflows, keep branch parameter as is.
+  const branchOrHash = core.getInput("branch", { required: false });
   const githubToken = core.getInput("github-token", { required: true });
 
   return {


### PR DESCRIPTION
Avoid breaking existing workflows, while still accepting a commit hash as input.