### PR TITLE
fix: pass cargo registry env vars to cargo check

### DIFF
--- a/dist/publish-crates-cargo-main.mjs
+++ b/dist/publish-crates-cargo-main.mjs
@@ -63611,8 +63611,17 @@ async function main(input) {
       const path = getPath(input);
       const options = {
         cwd: path,
-        check: true
+        check: true,
+        env: {}
       };
+      if (input.artifactoryToken) {
+        options.env = {
+          CARGO_REGISTRIES_ARTIFACTORY_TOKEN: input.artifactoryToken,
+          CARGO_REGISTRIES_ARTIFACTORY_INDEX: input.artifactoryIndex,
+          CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS: "cargo:token",
+          CARGO_REGISTRY_DEFAULT: "artifactory"
+        };
+      }
       for (const package_ of packagesOrdered(path)) {
         const command = ["cargo", "check", "-p", package_.name, "--manifest-path", package_.manifestPath];
         sh(command.join(" "), options);

--- a/src/publish-crates-cargo.ts
+++ b/src/publish-crates-cargo.ts
@@ -57,7 +57,17 @@ export async function main(input: Input) {
       const options = {
         cwd: path,
         check: true,
+        env: {},
       };
+
+      if (input.artifactoryToken) {
+        options.env = {
+          CARGO_REGISTRIES_ARTIFACTORY_TOKEN: input.artifactoryToken,
+          CARGO_REGISTRIES_ARTIFACTORY_INDEX: input.artifactoryIndex,
+          CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS: "cargo:token",
+          CARGO_REGISTRY_DEFAULT: "artifactory",
+        };
+      }
 
       for (const package_ of cargo.packagesOrdered(path)) {
         const command = ["cargo", "check", "-p", package_.name, "--manifest-path", package_.manifestPath];


### PR DESCRIPTION
During publication test cargo check also needs access to the registry.