### PR TITLE
fix: force installBinaryCached to use crates.io

### DIFF
--- a/dist/build-crates-debian-main.mjs
+++ b/dist/build-crates-debian-main.mjs
@@ -102582,17 +102582,18 @@ function packagesDebian(path2) {
   return result;
 }
 async function installBinaryCached(name) {
+  const env = { CARGO_REGISTRY_DEFAULT: "crates-io" };
   if (process.env["GITHUB_ACTIONS"] != void 0) {
     const paths = [join(os2.homedir(), ".cargo", "bin")];
     const version2 = config.lock.cratesio[name];
     const key = `${os2.platform()}-${os2.release()}-${os2.arch()}-${name}-${version2}`;
     const hit = await cache.restoreCache(paths, key);
     if (hit == void 0) {
-      sh(`cargo +stable install ${name} --force`);
+      sh(`cargo +stable install ${name} --force`, { env });
       await cache.saveCache(paths, key);
     }
   } else {
-    sh(`cargo +stable install ${name}`);
+    sh(`cargo +stable install ${name}`, { env });
   }
 }
 function buildDebian(path2, target, version2) {

--- a/dist/build-crates-standalone-main.mjs
+++ b/dist/build-crates-standalone-main.mjs
@@ -102546,17 +102546,18 @@ var gitEnv = {
 // src/cargo.ts
 var toml = await TOML.init();
 async function installBinaryCached(name) {
+  const env = { CARGO_REGISTRY_DEFAULT: "crates-io" };
   if (process.env["GITHUB_ACTIONS"] != void 0) {
     const paths = [join(os2.homedir(), ".cargo", "bin")];
     const version2 = config.lock.cratesio[name];
     const key = `${os2.platform()}-${os2.release()}-${os2.arch()}-${name}-${version2}`;
     const hit = await cache.restoreCache(paths, key);
     if (hit == void 0) {
-      sh(`cargo +stable install ${name} --force`);
+      sh(`cargo +stable install ${name} --force`, { env });
       await cache.saveCache(paths, key);
     }
   } else {
-    sh(`cargo +stable install ${name}`);
+    sh(`cargo +stable install ${name}`, { env });
   }
 }
 function build(path2, target) {

--- a/dist/bump-crates-main.mjs
+++ b/dist/bump-crates-main.mjs
@@ -63581,17 +63581,18 @@ async function bumpDependencies(path, pattern, version2, _branch) {
   core2.endGroup();
 }
 async function installBinaryCached(name) {
+  const env = { CARGO_REGISTRY_DEFAULT: "crates-io" };
   if (process.env["GITHUB_ACTIONS"] != void 0) {
     const paths = [join(os2.homedir(), ".cargo", "bin")];
     const version2 = config.lock.cratesio[name];
     const key = `${os2.platform()}-${os2.release()}-${os2.arch()}-${name}-${version2}`;
     const hit = await cache.restoreCache(paths, key);
     if (hit == void 0) {
-      sh(`cargo +stable install ${name} --force`);
+      sh(`cargo +stable install ${name} --force`, { env });
       await cache.saveCache(paths, key);
     }
   } else {
-    sh(`cargo +stable install ${name}`);
+    sh(`cargo +stable install ${name}`, { env });
   }
 }
 function toDebianVersion(version2, revision) {

--- a/dist/publish-crates-cargo-main.mjs
+++ b/dist/publish-crates-cargo-main.mjs
@@ -63549,17 +63549,18 @@ function* packagesOrdered(path, options) {
   }
 }
 async function installBinaryCached(name) {
+  const env = { CARGO_REGISTRY_DEFAULT: "crates-io" };
   if (process.env["GITHUB_ACTIONS"] != void 0) {
     const paths = [join(os2.homedir(), ".cargo", "bin")];
     const version2 = config.lock.cratesio[name];
     const key = `${os2.platform()}-${os2.release()}-${os2.arch()}-${name}-${version2}`;
     const hit = await cache.restoreCache(paths, key);
     if (hit == void 0) {
-      sh(`cargo +stable install ${name} --force`);
+      sh(`cargo +stable install ${name} --force`, { env });
       await cache.saveCache(paths, key);
     }
   } else {
-    sh(`cargo +stable install ${name}`);
+    sh(`cargo +stable install ${name}`, { env });
   }
 }
 function isPublished(pkg, options) {

--- a/dist/publish-crates-debian-main.mjs
+++ b/dist/publish-crates-debian-main.mjs
@@ -102574,17 +102574,18 @@ var gitEnv = {
 // src/cargo.ts
 var toml = await TOML.init();
 async function installBinaryCached(name) {
+  const env = { CARGO_REGISTRY_DEFAULT: "crates-io" };
   if (process.env["GITHUB_ACTIONS"] != void 0) {
     const paths = [join(os2.homedir(), ".cargo", "bin")];
     const version2 = config.lock.cratesio[name];
     const key = `${os2.platform()}-${os2.release()}-${os2.arch()}-${name}-${version2}`;
     const hit = await cache.restoreCache(paths, key);
     if (hit == void 0) {
-      sh(`cargo +stable install ${name} --force`);
+      sh(`cargo +stable install ${name} --force`, { env });
       await cache.saveCache(paths, key);
     }
   } else {
-    sh(`cargo +stable install ${name}`);
+    sh(`cargo +stable install ${name}`, { env });
   }
 }
 

--- a/dist/publish-crates-eclipse-main.mjs
+++ b/dist/publish-crates-eclipse-main.mjs
@@ -102571,17 +102571,18 @@ var gitEnv = {
 // src/cargo.ts
 var toml = await TOML.init();
 async function installBinaryCached(name) {
+  const env = { CARGO_REGISTRY_DEFAULT: "crates-io" };
   if (process.env["GITHUB_ACTIONS"] != void 0) {
     const paths = [join(os2.homedir(), ".cargo", "bin")];
     const version2 = config.lock.cratesio[name];
     const key = `${os2.platform()}-${os2.release()}-${os2.arch()}-${name}-${version2}`;
     const hit = await cache.restoreCache(paths, key);
     if (hit == void 0) {
-      sh(`cargo +stable install ${name} --force`);
+      sh(`cargo +stable install ${name} --force`, { env });
       await cache.saveCache(paths, key);
     }
   } else {
-    sh(`cargo +stable install ${name}`);
+    sh(`cargo +stable install ${name}`, { env });
   }
 }
 

--- a/dist/publish-crates-github-main.mjs
+++ b/dist/publish-crates-github-main.mjs
@@ -102551,17 +102551,18 @@ var gitEnv = {
 // src/cargo.ts
 var toml = await TOML.init();
 async function installBinaryCached(name) {
+  const env = { CARGO_REGISTRY_DEFAULT: "crates-io" };
   if (process.env["GITHUB_ACTIONS"] != void 0) {
     const paths = [join(os2.homedir(), ".cargo", "bin")];
     const version2 = config.lock.cratesio[name];
     const key = `${os2.platform()}-${os2.release()}-${os2.arch()}-${name}-${version2}`;
     const hit = await cache.restoreCache(paths, key);
     if (hit == void 0) {
-      sh(`cargo +stable install ${name} --force`);
+      sh(`cargo +stable install ${name} --force`, { env });
       await cache.saveCache(paths, key);
     }
   } else {
-    sh(`cargo +stable install ${name}`);
+    sh(`cargo +stable install ${name}`, { env });
   }
 }
 

--- a/dist/publish-crates-homebrew-main.mjs
+++ b/dist/publish-crates-homebrew-main.mjs
@@ -102578,17 +102578,18 @@ var gitEnv = {
 // src/cargo.ts
 var toml = await TOML.init();
 async function installBinaryCached(name) {
+  const env = { CARGO_REGISTRY_DEFAULT: "crates-io" };
   if (process.env["GITHUB_ACTIONS"] != void 0) {
     const paths = [join(os2.homedir(), ".cargo", "bin")];
     const version2 = config.lock.cratesio[name];
     const key = `${os2.platform()}-${os2.release()}-${os2.arch()}-${name}-${version2}`;
     const hit = await cache.restoreCache(paths, key);
     if (hit == void 0) {
-      sh(`cargo +stable install ${name} --force`);
+      sh(`cargo +stable install ${name} --force`, { env });
       await cache.saveCache(paths, key);
     }
   } else {
-    sh(`cargo +stable install ${name}`);
+    sh(`cargo +stable install ${name}`, { env });
   }
 }
 

--- a/dist/set-git-branch-main.mjs
+++ b/dist/set-git-branch-main.mjs
@@ -63558,17 +63558,18 @@ function setCargoLockVersion(cargoLockPath) {
   }
 }
 async function installBinaryCached(name) {
+  const env = { CARGO_REGISTRY_DEFAULT: "crates-io" };
   if (process.env["GITHUB_ACTIONS"] != void 0) {
     const paths = [join(os2.homedir(), ".cargo", "bin")];
     const version2 = config.lock.cratesio[name];
     const key = `${os2.platform()}-${os2.release()}-${os2.arch()}-${name}-${version2}`;
     const hit = await cache.restoreCache(paths, key);
     if (hit == void 0) {
-      sh(`cargo +stable install ${name} --force`);
+      sh(`cargo +stable install ${name} --force`, { env });
       await cache.saveCache(paths, key);
     }
   } else {
-    sh(`cargo +stable install ${name}`);
+    sh(`cargo +stable install ${name}`, { env });
   }
 }
 

--- a/dist/set-registry-main.mjs
+++ b/dist/set-registry-main.mjs
@@ -63536,17 +63536,18 @@ async function configRegistry(path, name, index) {
   await toml.set(configPath, ["registries", name, "index"], index);
 }
 async function installBinaryCached(name) {
+  const env = { CARGO_REGISTRY_DEFAULT: "crates-io" };
   if (process.env["GITHUB_ACTIONS"] != void 0) {
     const paths = [join(os2.homedir(), ".cargo", "bin")];
     const version2 = config.lock.cratesio[name];
     const key = `${os2.platform()}-${os2.release()}-${os2.arch()}-${name}-${version2}`;
     const hit = await cache.restoreCache(paths, key);
     if (hit == void 0) {
-      sh(`cargo +stable install ${name} --force`);
+      sh(`cargo +stable install ${name} --force`, { env });
       await cache.saveCache(paths, key);
     }
   } else {
-    sh(`cargo +stable install ${name}`);
+    sh(`cargo +stable install ${name}`, { env });
   }
 }
 

--- a/src/cargo.ts
+++ b/src/cargo.ts
@@ -405,6 +405,9 @@ export function installBinaryFromGit(name: string, gitUrl: string, gitBranch: st
  * @param name Name of the cargo binary on crates.io
  */
 export async function installBinaryCached(name: string) {
+  // Force cargo to use crates.io registry
+  const env = { CARGO_REGISTRY_DEFAULT: "crates-io" };
+
   if (process.env["GITHUB_ACTIONS"] != undefined) {
     const paths = [join(os.homedir(), ".cargo", "bin")];
     const version = config.lock.cratesio[name];
@@ -414,14 +417,13 @@ export async function installBinaryCached(name: string) {
     // toolchain file in the current directory, as the caller can use this
     // function with an arbitrary Rust toolchain, often resulting in build
     // failure
-
     const hit = await cache.restoreCache(paths, key);
     if (hit == undefined) {
-      sh(`cargo +stable install ${name} --force`);
+      sh(`cargo +stable install ${name} --force`, { env: env });
       await cache.saveCache(paths, key);
     }
   } else {
-    sh(`cargo +stable install ${name}`);
+    sh(`cargo +stable install ${name}`, { env: env });
   }
 }
 


### PR DESCRIPTION
cargo tooling used by numerous actions (toml-cli2, cross, cargo-deb) should be installed from crates.io.