### PR TITLE
fix: add toolchain input to bump crates

### DIFF
--- a/bump-crates/action.yml
+++ b/bump-crates/action.yml
@@ -11,6 +11,8 @@ inputs:
     required: true
   path:
     required: false
+  toolchain:
+    required: false
   github-token:
     required: true
   bump-deps-pattern:

--- a/dist/bump-crates-main.mjs
+++ b/dist/bump-crates-main.mjs
@@ -63624,6 +63624,7 @@ function setup() {
   const branch = core3.getInput("branch", { required: true });
   const repo = core3.getInput("repo", { required: true });
   const path = core3.getInput("path");
+  const toolchain = core3.getInput("toolchain");
   const githubToken = core3.getInput("github-token", { required: true });
   const bumpDepsPattern = core3.getInput("bump-deps-pattern");
   const bumpDepsVersion = core3.getInput("bump-deps-version");
@@ -63634,6 +63635,8 @@ function setup() {
     branch,
     repo,
     path: path === "" ? void 0 : path,
+    toolchain: toolchain === "" ? "1.75.0" : toolchain,
+    // Default to 1.75.0 to avoid updating Cargo.lock file version.
     githubToken,
     bumpDepsRegExp: bumpDepsPattern === "" ? void 0 : new RegExp(bumpDepsPattern),
     bumpDepsVersion: bumpDepsVersion === "" ? version2 : bumpDepsVersion,
@@ -63658,7 +63661,7 @@ async function main(input) {
         env: gitEnv,
         check: false
       });
-      sh("cargo +1.75.0 check", { cwd: repo });
+      sh("cargo +${input.toolchain} check", { cwd: repo });
       sh("git commit Cargo.lock --message 'chore: Update Cargo lockfile'", {
         cwd: repo,
         env: gitEnv,

--- a/src/bump-crates.ts
+++ b/src/bump-crates.ts
@@ -13,6 +13,7 @@ export type Input = {
   branch: string;
   repo: string;
   path?: string;
+  toolchain?: string;
   githubToken: string;
   bumpDepsRegExp?: RegExp;
   bumpDepsVersion: string;
@@ -25,6 +26,7 @@ export function setup(): Input {
   const branch = core.getInput("branch", { required: true });
   const repo = core.getInput("repo", { required: true });
   const path = core.getInput("path");
+  const toolchain = core.getInput("toolchain");
   const githubToken = core.getInput("github-token", { required: true });
   const bumpDepsPattern = core.getInput("bump-deps-pattern");
   const bumpDepsVersion = core.getInput("bump-deps-version");
@@ -36,6 +38,7 @@ export function setup(): Input {
     branch,
     repo,
     path: path === "" ? undefined : path,
+    toolchain: toolchain === "" ? "1.75.0" : toolchain, // Default to 1.75.0 to avoid updating Cargo.lock file version.
     githubToken,
     bumpDepsRegExp: bumpDepsPattern === "" ? undefined : new RegExp(bumpDepsPattern),
     bumpDepsVersion: bumpDepsVersion === "" ? version : bumpDepsVersion,
@@ -65,8 +68,7 @@ export async function main(input: Input) {
         check: false,
       });
 
-      // use 1.75 to avoid update the Cargo.lock file version.
-      sh("cargo +1.75.0 check", { cwd: repo });
+      sh("cargo +${input.toolchain} check", { cwd: repo });
       sh("git commit Cargo.lock --message 'chore: Update Cargo lockfile'", {
         cwd: repo,
         env: gitEnv,


### PR DESCRIPTION
This way we default to 1.75.0 but allow consumers of bump-crates to override to an arbitrary toolchain (e.g. https://github.com/eclipse-zenoh/zenoh-dissector/actions/runs/15547337338/job/43771268582)