### PR TITLE
chore: use debsigs instead of dpkg-sig

### DIFF
--- a/dist/publish-crates-debian-main.mjs
+++ b/dist/publish-crates-debian-main.mjs
@@ -102639,12 +102639,12 @@ async function main(input) {
       }
     }
     sh("sudo apt-get update");
-    sh("sudo apt-get install -y dpkg-dev apt-utils gpg");
+    sh("sudo apt-get install -y dpkg-dev apt-utils gpg devscripts debsigs");
     const dirents = await fs4.readdir(`${input.version}`, { withFileTypes: true });
     const files = dirents.filter((d) => d.name.endsWith(".deb"));
     files.forEach((file) => {
       const filePath = path.join(`${input.version}`, file.name);
-      sh(`dpkg-sig --sign builder -k ${input.gpgKeyId} ${filePath}`);
+      sh(`debsigs --sign=origin -k ${input.gpgKeyId} ${filePath}`);
     });
     const debianRepo = `${input.sshHost}:${input.sshHostPath}`;
     const gitRepo = input.repo.split("/")[1];

--- a/src/publish-crates-debian.ts
+++ b/src/publish-crates-debian.ts
@@ -68,14 +68,14 @@ export async function main(input: Input) {
     }
 
     sh("sudo apt-get update");
-    sh("sudo apt-get install -y dpkg-dev apt-utils gpg");
+    sh("sudo apt-get install -y dpkg-dev apt-utils gpg devscripts debsigs");
 
     // Sign the .deb files
     const dirents = await fs.readdir(`${input.version}`, { withFileTypes: true });
     const files = dirents.filter(d => d.name.endsWith(".deb"));
     files.forEach(file => {
       const filePath = path.join(`${input.version}`, file.name);
-      sh(`dpkg-sig --sign builder -k ${input.gpgKeyId} ${filePath}`);
+      sh(`debsigs --sign=origin -k ${input.gpgKeyId} ${filePath}`);
     });
 
     const debianRepo = `${input.sshHost}:${input.sshHostPath}`;


### PR DESCRIPTION
dpkg-sig has been deprecated on Ubuntu 24.04