### PR TITLE
chore: update cargo-deb to 3.4.1

### DIFF
--- a/ci.config.json
+++ b/ci.config.json
@@ -7,7 +7,7 @@
   },
   "lock": {
     "cratesio": {
-      "cargo-deb": "2.1.0",
+      "cargo-deb": "3.4.1",
       "estuary": "0.1.1",
       "cross": "0.2.5",
       "toml-cli2": "0.3.2"

--- a/dist/build-crates-debian-main.mjs
+++ b/dist/build-crates-debian-main.mjs
@@ -102521,7 +102521,7 @@ var ci_config_default = {
   },
   lock: {
     cratesio: {
-      "cargo-deb": "2.1.0",
+      "cargo-deb": "3.4.1",
       estuary: "0.1.1",
       cross: "0.2.5",
       "toml-cli2": "0.3.2"

--- a/dist/build-crates-standalone-main.mjs
+++ b/dist/build-crates-standalone-main.mjs
@@ -102520,7 +102520,7 @@ var ci_config_default = {
   },
   lock: {
     cratesio: {
-      "cargo-deb": "2.1.0",
+      "cargo-deb": "3.4.1",
       estuary: "0.1.1",
       cross: "0.2.5",
       "toml-cli2": "0.3.2"

--- a/dist/bump-crates-main.mjs
+++ b/dist/bump-crates-main.mjs
@@ -63484,7 +63484,7 @@ var ci_config_default = {
   },
   lock: {
     cratesio: {
-      "cargo-deb": "2.1.0",
+      "cargo-deb": "3.4.1",
       estuary: "0.1.1",
       cross: "0.2.5",
       "toml-cli2": "0.3.2"

--- a/dist/publish-crates-cargo-main.mjs
+++ b/dist/publish-crates-cargo-main.mjs
@@ -63485,7 +63485,7 @@ var ci_config_default = {
   },
   lock: {
     cratesio: {
-      "cargo-deb": "2.1.0",
+      "cargo-deb": "3.4.1",
       estuary: "0.1.1",
       cross: "0.2.5",
       "toml-cli2": "0.3.2"

--- a/dist/publish-crates-debian-main.mjs
+++ b/dist/publish-crates-debian-main.mjs
@@ -102548,7 +102548,7 @@ var ci_config_default = {
   },
   lock: {
     cratesio: {
-      "cargo-deb": "2.1.0",
+      "cargo-deb": "3.4.1",
       estuary: "0.1.1",
       cross: "0.2.5",
       "toml-cli2": "0.3.2"

--- a/dist/publish-crates-eclipse-main.mjs
+++ b/dist/publish-crates-eclipse-main.mjs
@@ -102545,7 +102545,7 @@ var ci_config_default = {
   },
   lock: {
     cratesio: {
-      "cargo-deb": "2.1.0",
+      "cargo-deb": "3.4.1",
       estuary: "0.1.1",
       cross: "0.2.5",
       "toml-cli2": "0.3.2"

--- a/dist/publish-crates-github-main.mjs
+++ b/dist/publish-crates-github-main.mjs
@@ -102525,7 +102525,7 @@ var ci_config_default = {
   },
   lock: {
     cratesio: {
-      "cargo-deb": "2.1.0",
+      "cargo-deb": "3.4.1",
       estuary: "0.1.1",
       cross: "0.2.5",
       "toml-cli2": "0.3.2"

--- a/dist/publish-crates-homebrew-main.mjs
+++ b/dist/publish-crates-homebrew-main.mjs
@@ -102552,7 +102552,7 @@ var ci_config_default = {
   },
   lock: {
     cratesio: {
-      "cargo-deb": "2.1.0",
+      "cargo-deb": "3.4.1",
       estuary: "0.1.1",
       cross: "0.2.5",
       "toml-cli2": "0.3.2"

--- a/dist/set-git-branch-main.mjs
+++ b/dist/set-git-branch-main.mjs
@@ -63484,7 +63484,7 @@ var ci_config_default = {
   },
   lock: {
     cratesio: {
-      "cargo-deb": "2.1.0",
+      "cargo-deb": "3.4.1",
       estuary: "0.1.1",
       cross: "0.2.5",
       "toml-cli2": "0.3.2"

--- a/dist/set-registry-main.mjs
+++ b/dist/set-registry-main.mjs
@@ -63484,7 +63484,7 @@ var ci_config_default = {
   },
   lock: {
     cratesio: {
-      "cargo-deb": "2.1.0",
+      "cargo-deb": "3.4.1",
       estuary: "0.1.1",
       cross: "0.2.5",
       "toml-cli2": "0.3.2"


### PR DESCRIPTION
Possible fix for https://github.com/eclipse-zenoh/zenoh/actions/runs/16818562700/job/47640925943