### PR TITLE
feat: allow bump-crates to set multi version deps

### DIFF
--- a/bump-crates/action.yml
+++ b/bump-crates/action.yml
@@ -16,16 +16,12 @@ inputs:
   github-token:
     required: true
   bump-deps-pattern:
-    required: false
-  bump-deps-version:
-    required: false
-  bump-deps-branch:
-    required: false
-  bump-deps-patterns:
     description: "Multiline list of regular expressions for dependencies to bump (one per line)"
     required: false
-  bump-deps-versions:
+  bump-deps-version:
     description: "Multiline list of versions, matching bump-deps-patterns (one per line)"
+    required: false
+  bump-deps-branch:
     required: false
 
 runs:

--- a/bump-crates/action.yml
+++ b/bump-crates/action.yml
@@ -21,6 +21,12 @@ inputs:
     required: false
   bump-deps-branch:
     required: false
+  bump-deps-patterns:
+    description: "Multiline list of regular expressions for dependencies to bump (one per line)"
+    required: false
+  bump-deps-versions:
+    description: "Multiline list of versions, matching bump-deps-patterns (one per line)"
+    required: false
 
 runs:
   using: node20

--- a/dist/bump-crates-main.mjs
+++ b/dist/bump-crates-main.mjs
@@ -63633,6 +63633,11 @@ function setup() {
   const bumpDepsVersionsRaw = core3.getMultilineInput("bump-deps-versions");
   let bumpDepsPatterns = void 0;
   let bumpDepsVersions = void 0;
+  if (bumpDepsPatternsRaw.length > 0 && bumpDepsVersionsRaw.length === 0 || bumpDepsPatternsRaw.length === 0 && bumpDepsVersionsRaw.length > 0) {
+    throw new Error(
+      "Both bump-deps-patterns and bump-deps-versions must be provided together (either both empty or both non-empty)."
+    );
+  }
   if (bumpDepsPatternsRaw.length > 0 && bumpDepsVersionsRaw.length > 0) {
     if (bumpDepsPatternsRaw.length !== bumpDepsVersionsRaw.length) {
       throw new Error(`bump-deps-patterns and bump-deps-versions must have the same number of lines`);
@@ -63666,7 +63671,7 @@ async function main(input) {
     await bump(workspace, input.version);
     sh("git add .", { cwd: repo });
     sh(`git commit --message 'chore: Bump version to \`${input.version}\`'`, { cwd: repo, env: gitEnv });
-    if (input.bumpDepsPatterns && input.bumpDepsVersions) {
+    if (input.bumpDepsPatterns && input.bumpDepsVersions && input.bumpDepsPatterns.length === input.bumpDepsVersions.length) {
       for (let i = 0; i < input.bumpDepsPatterns.length; i++) {
         await bumpDependencies(
           workspace,
@@ -63676,7 +63681,7 @@ async function main(input) {
         );
         sh("git add .", { cwd: repo });
         sh(
-          `git commit --message 'chore: Bump ${input.bumpDepsPatterns[i]} dependencies to \`${input.bumpDepsVersions[i]}\`'`,
+          `git commit --message 'chore: Bump ${input.bumpDepsPatterns[i].source} dependencies to \`${input.bumpDepsVersions[i]}\`'`,
           { cwd: repo, env: gitEnv, check: false }
         );
       }

--- a/dist/bump-crates-main.mjs
+++ b/dist/bump-crates-main.mjs
@@ -63633,12 +63633,12 @@ function setup() {
   let bumpDepsVersion = void 0;
   if (bumpDepsPatternRaw.length > 0 && bumpDepsVersionRaw.length === 0 || bumpDepsPatternRaw.length === 0 && bumpDepsVersionRaw.length > 0) {
     throw new Error(
-      "Both bump-deps-patterns and bump-deps-versions must be provided together (either both empty or both non-empty)."
+      "Both bump-deps-pattern and bump-deps-version must be provided together (either both empty or both non-empty)."
     );
   }
   if (bumpDepsPatternRaw.length > 0 && bumpDepsVersionRaw.length > 0) {
     if (bumpDepsPatternRaw.length !== bumpDepsVersionRaw.length) {
-      throw new Error(`bump-deps-patterns and bump-deps-versions must have the same number of lines`);
+      throw new Error(`bump-deps-pattern and bump-deps-version must have the same number of lines`);
     }
     bumpDepsPattern = bumpDepsPatternRaw.map((pat) => new RegExp(pat));
     bumpDepsVersion = bumpDepsVersionRaw;

--- a/src/bump-crates.ts
+++ b/src/bump-crates.ts
@@ -40,12 +40,12 @@ export function setup(): Input {
     (bumpDepsPatternRaw.length === 0 && bumpDepsVersionRaw.length > 0)
   ) {
     throw new Error(
-      "Both bump-deps-patterns and bump-deps-versions must be provided together (either both empty or both non-empty).",
+      "Both bump-deps-pattern and bump-deps-version must be provided together (either both empty or both non-empty).",
     );
   }
   if (bumpDepsPatternRaw.length > 0 && bumpDepsVersionRaw.length > 0) {
     if (bumpDepsPatternRaw.length !== bumpDepsVersionRaw.length) {
-      throw new Error(`bump-deps-patterns and bump-deps-versions must have the same number of lines`);
+      throw new Error(`bump-deps-pattern and bump-deps-version must have the same number of lines`);
     }
     bumpDepsPattern = bumpDepsPatternRaw.map(pat => new RegExp(pat));
     bumpDepsVersion = bumpDepsVersionRaw;

--- a/src/bump-crates.ts
+++ b/src/bump-crates.ts
@@ -76,7 +76,11 @@ export async function main(input: Input) {
     sh("git add .", { cwd: repo });
     sh(`git commit --message 'chore: Bump version to \`${input.version}\`'`, { cwd: repo, env: gitEnv });
 
-    if (input.bumpDepsPatterns && input.bumpDepsVersions) {
+    if (
+      input.bumpDepsPatterns &&
+      input.bumpDepsVersions &&
+      input.bumpDepsPatterns.length === input.bumpDepsVersions.length
+    ) {
       for (let i = 0; i < input.bumpDepsPatterns.length; i++) {
         await cargo.bumpDependencies(
           workspace,

--- a/src/bump-crates.ts
+++ b/src/bump-crates.ts
@@ -15,10 +15,8 @@ export type Input = {
   path?: string;
   toolchain?: string;
   githubToken: string;
-  bumpDepsPatterns?: RegExp[];
-  bumpDepsVersions?: string[];
-  bumpDepsRegExp?: RegExp;
-  bumpDepsVersion: string;
+  bumpDepsPattern?: RegExp[];
+  bumpDepsVersion?: string[];
   bumpDepsBranch?: string;
 };
 
@@ -30,29 +28,27 @@ export function setup(): Input {
   const path = core.getInput("path");
   const toolchain = core.getInput("toolchain");
   const githubToken = core.getInput("github-token", { required: true });
-  const bumpDepsPattern = core.getInput("bump-deps-pattern");
-  const bumpDepsVersion = core.getInput("bump-deps-version");
   const bumpDepsBranch = core.getInput("bump-deps-branch");
-  const bumpDepsPatternsRaw = core.getMultilineInput("bump-deps-patterns");
-  const bumpDepsVersionsRaw = core.getMultilineInput("bump-deps-versions");
+  const bumpDepsPatternRaw = core.getMultilineInput("bump-deps-pattern");
+  const bumpDepsVersionRaw = core.getMultilineInput("bump-deps-version");
   // Parse multiline inputs if provided
-  let bumpDepsPatterns: RegExp[] | undefined = undefined;
-  let bumpDepsVersions: string[] | undefined = undefined;
+  let bumpDepsPattern: RegExp[] | undefined = undefined;
+  let bumpDepsVersion: string[] | undefined = undefined;
 
   if (
-    (bumpDepsPatternsRaw.length > 0 && bumpDepsVersionsRaw.length === 0) ||
-    (bumpDepsPatternsRaw.length === 0 && bumpDepsVersionsRaw.length > 0)
+    (bumpDepsPatternRaw.length > 0 && bumpDepsVersionRaw.length === 0) ||
+    (bumpDepsPatternRaw.length === 0 && bumpDepsVersionRaw.length > 0)
   ) {
     throw new Error(
       "Both bump-deps-patterns and bump-deps-versions must be provided together (either both empty or both non-empty).",
     );
   }
-  if (bumpDepsPatternsRaw.length > 0 && bumpDepsVersionsRaw.length > 0) {
-    if (bumpDepsPatternsRaw.length !== bumpDepsVersionsRaw.length) {
+  if (bumpDepsPatternRaw.length > 0 && bumpDepsVersionRaw.length > 0) {
+    if (bumpDepsPatternRaw.length !== bumpDepsVersionRaw.length) {
       throw new Error(`bump-deps-patterns and bump-deps-versions must have the same number of lines`);
     }
-    bumpDepsPatterns = bumpDepsPatternsRaw.map(pat => new RegExp(pat));
-    bumpDepsVersions = bumpDepsVersionsRaw;
+    bumpDepsPattern = bumpDepsPatternRaw.map(pat => new RegExp(pat));
+    bumpDepsVersion = bumpDepsVersionRaw;
   }
 
   return {
@@ -63,11 +59,9 @@ export function setup(): Input {
     path: path === "" ? undefined : path,
     toolchain: toolchain === "" ? "1.75.0" : toolchain, // Default to 1.75.0 to avoid updating Cargo.lock file version.
     githubToken,
-    bumpDepsRegExp: bumpDepsPattern === "" ? undefined : new RegExp(bumpDepsPattern),
-    bumpDepsVersion: bumpDepsVersion === "" ? version : bumpDepsVersion,
+    bumpDepsPattern,
+    bumpDepsVersion,
     bumpDepsBranch: bumpDepsBranch === "" ? undefined : bumpDepsBranch,
-    bumpDepsPatterns,
-    bumpDepsVersions,
   };
 }
 
@@ -85,40 +79,31 @@ export async function main(input: Input) {
     sh(`git commit --message 'chore: Bump version to \`${input.version}\`'`, { cwd: repo, env: gitEnv });
 
     if (
-      input.bumpDepsPatterns &&
-      input.bumpDepsVersions &&
-      input.bumpDepsPatterns.length === input.bumpDepsVersions.length
+      input.bumpDepsPattern &&
+      input.bumpDepsVersion &&
+      input.bumpDepsPattern.length === input.bumpDepsVersion.length
     ) {
-      for (let i = 0; i < input.bumpDepsPatterns.length; i++) {
+      for (let i = 0; i < input.bumpDepsPattern.length; i++) {
         await cargo.bumpDependencies(
           workspace,
-          input.bumpDepsPatterns[i],
-          input.bumpDepsVersions[i],
+          input.bumpDepsPattern[i],
+          input.bumpDepsVersion[i],
           input.bumpDepsBranch,
         );
         sh("git add .", { cwd: repo });
         sh(
-          `git commit --message 'chore: Bump ${input.bumpDepsPatterns[i].source} dependencies to \`${input.bumpDepsVersions[i]}\`'`,
+          `git commit --message 'chore: Bump ${input.bumpDepsPattern[i].source} dependencies to \`${input.bumpDepsVersion[i]}\`'`,
           { cwd: repo, env: gitEnv, check: false },
         );
       }
-    } else if (input.bumpDepsRegExp != undefined) {
-      // keep current behavior for backwards compatibility
-      await cargo.bumpDependencies(workspace, input.bumpDepsRegExp, input.bumpDepsVersion, input.bumpDepsBranch);
-      sh("git add .", { cwd: repo });
-      sh(`git commit --message 'chore: Bump ${input.bumpDepsRegExp} dependencies to \`${input.bumpDepsVersion}\`'`, {
+
+      sh(`cargo +${input.toolchain} check`, { cwd: repo });
+      sh("git commit Cargo.lock --message 'chore: Update Cargo lockfile'", {
         cwd: repo,
         env: gitEnv,
         check: false,
       });
     }
-
-    sh(`cargo +${input.toolchain} check`, { cwd: repo });
-    sh("git commit Cargo.lock --message 'chore: Update Cargo lockfile'", {
-      cwd: repo,
-      env: gitEnv,
-      check: false,
-    });
 
     sh(`git push --force ${remote} ${input.branch}`, { cwd: repo });
 

--- a/src/bump-crates.ts
+++ b/src/bump-crates.ts
@@ -44,7 +44,7 @@ export function setup(): Input {
     (bumpDepsPatternsRaw.length === 0 && bumpDepsVersionsRaw.length > 0)
   ) {
     throw new Error(
-      "Both bump-deps-patterns and bump-deps-versions must be provided together (either both empty or both non-empty)."
+      "Both bump-deps-patterns and bump-deps-versions must be provided together (either both empty or both non-empty).",
     );
   }
   if (bumpDepsPatternsRaw.length > 0 && bumpDepsVersionsRaw.length > 0) {

--- a/src/bump-crates.ts
+++ b/src/bump-crates.ts
@@ -86,7 +86,7 @@ export async function main(input: Input) {
         );
         sh("git add .", { cwd: repo });
         sh(
-          `git commit --message 'chore: Bump ${input.bumpDepsPatterns[i]} dependencies to \`${input.bumpDepsVersions[i]}\`'`,
+          `git commit --message 'chore: Bump ${input.bumpDepsPatterns[i].source} dependencies to \`${input.bumpDepsVersions[i]}\`'`,
           { cwd: repo, env: gitEnv, check: false },
         );
       }

--- a/src/bump-crates.ts
+++ b/src/bump-crates.ts
@@ -39,6 +39,14 @@ export function setup(): Input {
   let bumpDepsPatterns: RegExp[] | undefined = undefined;
   let bumpDepsVersions: string[] | undefined = undefined;
 
+  if (
+    (bumpDepsPatternsRaw.length > 0 && bumpDepsVersionsRaw.length === 0) ||
+    (bumpDepsPatternsRaw.length === 0 && bumpDepsVersionsRaw.length > 0)
+  ) {
+    throw new Error(
+      "Both bump-deps-patterns and bump-deps-versions must be provided together (either both empty or both non-empty)."
+    );
+  }
   if (bumpDepsPatternsRaw.length > 0 && bumpDepsVersionsRaw.length > 0) {
     if (bumpDepsPatternsRaw.length !== bumpDepsVersionsRaw.length) {
       throw new Error(`bump-deps-patterns and bump-deps-versions must have the same number of lines`);


### PR DESCRIPTION
This allows to set different versions for dependencies, something like: 
```
          bump-deps-patterns: |
            ^(zenoh-admin-client|zenoh_admin_interface)$
            ^zenoh(?!-admin-client|_admin_interface)[a-zA-Z0-9-_]*$
          bump-deps-versions: |
            ${{ inputs.version }}
            ${{ inputs.zenoh_version }}
``` 

Useful for plugins like the zenoh-plugin-admin which has a different version than the zenoh version