### PR TITLE
fix: always unset registry during set-git-branch

### DIFF
--- a/dist/set-git-branch-main.mjs
+++ b/dist/set-git-branch-main.mjs
@@ -63526,8 +63526,8 @@ async function setGitBranch(manifestPath, pattern, gitUrl, gitBranch) {
       if (!(toml.get(manifestPath, prefix2.concat("dependencies", dep, "path")) || toml.get(manifestPath, prefix2.concat("dependencies", dep, "workspace")))) {
         await toml.set(manifestPath, prefix2.concat("dependencies", dep, "git"), gitUrl);
         await toml.set(manifestPath, prefix2.concat("dependencies", dep, "branch"), gitBranch);
-        await toml.unset(manifestPath, prefix2.concat("dependencies", dep, "registry"));
       }
+      await toml.unset(manifestPath, prefix2.concat("dependencies", dep, "registry"));
     }
   }
   for (const dep in manifest["build-dependencies"]) {
@@ -63535,8 +63535,8 @@ async function setGitBranch(manifestPath, pattern, gitUrl, gitBranch) {
       if (!(toml.get(manifestPath, prefix2.concat("build-dependencies", dep, "path")) || toml.get(manifestPath, prefix2.concat("build-dependencies", dep, "workspace")))) {
         await toml.set(manifestPath, prefix2.concat("build-dependencies", dep, "git"), gitUrl);
         await toml.set(manifestPath, prefix2.concat("build-dependencies", dep, "branch"), gitBranch);
-        await toml.unset(manifestPath, prefix2.concat("dependencies", dep, "registry"));
       }
+      await toml.unset(manifestPath, prefix2.concat("dependencies", dep, "registry"));
     }
   }
   if (manifest.metadata != void 0) {
@@ -63545,8 +63545,8 @@ async function setGitBranch(manifestPath, pattern, gitUrl, gitBranch) {
         if (!(toml.get(manifestPath, prefix2.concat("metadata", "bin", dep, "path")) || toml.get(manifestPath, prefix2.concat("metadata", "bin", dep, "workspace")))) {
           await toml.set(manifestPath, prefix2.concat("metadata", "bin", dep, "git"), gitUrl);
           await toml.set(manifestPath, prefix2.concat("metadata", "bin", dep, "branch"), gitBranch);
-          await toml.unset(manifestPath, prefix2.concat("dependencies", dep, "registry"));
         }
+        await toml.unset(manifestPath, prefix2.concat("dependencies", dep, "registry"));
       }
     }
   }

--- a/src/cargo.ts
+++ b/src/cargo.ts
@@ -328,9 +328,9 @@ export async function setGitBranch(
       ) {
         await toml.set(manifestPath, prefix.concat("dependencies", dep, "git"), gitUrl);
         await toml.set(manifestPath, prefix.concat("dependencies", dep, "branch"), gitBranch);
-        // NOTE: Only one of `git` or `registry` is allowed, otherwise the specification is ambiguous
-        await toml.unset(manifestPath, prefix.concat("dependencies", dep, "registry"));
       }
+      // NOTE: Only one of `git` or `registry` is allowed, otherwise the specification is ambiguous
+      await toml.unset(manifestPath, prefix.concat("dependencies", dep, "registry"));
     }
   }
 
@@ -345,9 +345,9 @@ export async function setGitBranch(
       ) {
         await toml.set(manifestPath, prefix.concat("build-dependencies", dep, "git"), gitUrl);
         await toml.set(manifestPath, prefix.concat("build-dependencies", dep, "branch"), gitBranch);
-        // NOTE: Only one of `git` or `registry` is allowed, otherwise the specification is ambiguous
-        await toml.unset(manifestPath, prefix.concat("dependencies", dep, "registry"));
       }
+      // NOTE: Only one of `git` or `registry` is allowed, otherwise the specification is ambiguous
+      await toml.unset(manifestPath, prefix.concat("dependencies", dep, "registry"));
     }
   }
 
@@ -363,9 +363,9 @@ export async function setGitBranch(
         ) {
           await toml.set(manifestPath, prefix.concat("metadata", "bin", dep, "git"), gitUrl);
           await toml.set(manifestPath, prefix.concat("metadata", "bin", dep, "branch"), gitBranch);
-          // NOTE: Only one of `git` or `registry` is allowed, otherwise the specification is ambiguous
-          await toml.unset(manifestPath, prefix.concat("dependencies", dep, "registry"));
         }
+        // NOTE: Only one of `git` or `registry` is allowed, otherwise the specification is ambiguous
+        await toml.unset(manifestPath, prefix.concat("dependencies", dep, "registry"));
       }
     }
   }


### PR DESCRIPTION
Don't skip path/workspace deps since those also have registry key