### PR TITLE
fix: pass toolchain input for zenoh-dissector

### DIFF
--- a/.github/workflows/merge-release-branch.yml
+++ b/.github/workflows/merge-release-branch.yml
@@ -61,7 +61,20 @@ jobs:
           sudo apt install -y --allow-change-held-packages wireshark
 
       - name: Update git/branch in release branch
-        if: ${{ !contains(fromJSON('["eclipse-zenoh/zenoh", "eclipse-zenoh/zenoh-pico", "eclipse-zenoh/zenoh-cpp"]'), matrix.repo) }}
+        if: ${{ matrix.repo == 'eclipse-zenoh/zenoh-dissector' }}
+        uses: eclipse-zenoh/ci/set-git-branch@main
+        with:
+          version: ${{ inputs.version }}
+          release-branch: release/${{ inputs.version }}
+          repo: ${{ matrix.repo }}
+          github-token: ${{ secrets.BOT_TOKEN_WORKFLOW }}
+          toolchain: 1.85.0
+          deps-pattern: zenoh.*
+          deps-git-url: https://github.com/eclipse-zenoh/zenoh.git
+          deps-branch: main
+
+      - name: Update git/branch in release branch
+        if: ${{ !contains(fromJSON('["eclipse-zenoh/zenoh", "eclipse-zenoh/zenoh-pico", "eclipse-zenoh/zenoh-cpp", "eclipse-zenoh/zenoh-dissector"]'), matrix.repo) }}
         uses: eclipse-zenoh/ci/set-git-branch@main
         with:
           version: ${{ inputs.version }}

--- a/set-git-branch/action.yml
+++ b/set-git-branch/action.yml
@@ -9,6 +9,8 @@ inputs:
     required: true
   path:
     required: false
+  toolchain:
+    required: false
   github-token:
     required: true
   github-user:


### PR DESCRIPTION
Use 1.85.0 toolchain for zenoh-dissector. Fix https://github.com/eclipse-zenoh/ci/actions/runs/18507584630/job/52774106155