### PR TITLE
chore: fix bump-crates to push tags

### DIFF
--- a/dist/bump-crates-main.mjs
+++ b/dist/bump-crates-main.mjs
@@ -63707,7 +63707,7 @@ async function main(input) {
     if (input.liveRun) {
       const tag = input.tag === "" ? input.version : input.tag;
       sh(`git tag --force ${tag} --message v${tag}`, { cwd: repo, env: gitEnv });
-      sh(`git push --force ${remote} ${input.version}`, { cwd: repo });
+      sh(`git push --force ${remote} ${tag}`, { cwd: repo });
     }
     sh("git log -10", { cwd: repo });
     sh("git show-ref --tags", { cwd: repo });

--- a/src/bump-crates.ts
+++ b/src/bump-crates.ts
@@ -118,7 +118,7 @@ export async function main(input: Input) {
     if (input.liveRun) {
       const tag = input.tag === "" ? input.version : input.tag;
       sh(`git tag --force ${tag} --message v${tag}`, { cwd: repo, env: gitEnv });
-      sh(`git push --force ${remote} ${input.version}`, { cwd: repo });
+      sh(`git push --force ${remote} ${tag}`, { cwd: repo });
     }
 
     sh("git log -10", { cwd: repo });


### PR DESCRIPTION
Correctly push tags if input.tag is defined, otherwise use input.version