### PR TITLE
fix: kellnr publication don't need to use --locked

### DIFF
--- a/dist/publish-crates-cargo-main.mjs
+++ b/dist/publish-crates-cargo-main.mjs
@@ -70185,9 +70185,11 @@ function publish(path, env, allowDirty = false) {
   };
   for (const package_ of packagesOrdered(path, options)) {
     if (!isPublished(package_, options) && (package_.publish === void 0 || package_.publish)) {
-      const command = ["cargo", "publish", "--locked", "--manifest-path", package_.manifestPath];
+      const command = ["cargo", "publish", "--manifest-path", package_.manifestPath];
       if (allowDirty) {
         command.push("--allow-dirty");
+      } else {
+        command.push("--locked");
       }
       sh(command.join(" "), options);
     }

--- a/src/publish-crates-cargo.ts
+++ b/src/publish-crates-cargo.ts
@@ -195,9 +195,11 @@ function publish(path: string, env: NodeJS.ProcessEnv, allowDirty: boolean = fal
   for (const package_ of cargo.packagesOrdered(path, options)) {
     // Crates.io won't allow packages to be published with the same version
     if (!cargo.isPublished(package_, options) && (package_.publish === undefined || package_.publish)) {
-      const command = ["cargo", "publish", "--locked", "--manifest-path", package_.manifestPath];
+      const command = ["cargo", "publish", "--manifest-path", package_.manifestPath];
       if (allowDirty) {
         command.push("--allow-dirty");
+      } else {
+        command.push("--locked");
       }
       sh(command.join(" "), options);
     }


### PR DESCRIPTION
On regular runs, where allowDirty is false, we'll still use --locked for publication (crates.io or artifactory).
If allowDirty is true, then we're publishing to kellnr, so we don't use the --locked arg. This allows to test publication of plugins and backend, using eclipse-zenoh/zenoh:main for zenoh deps