### PR TITLE
chore: add internal label to sync/recreate PRs

### DIFF
--- a/.github/workflows/recreate-lockfile.yml
+++ b/.github/workflows/recreate-lockfile.yml
@@ -7,13 +7,11 @@ on:
     inputs:
       branch:
         type: string
-        description:
-          The branch to sync across all dependent repositories. Defaults to the default branch of the source repository (i.e. eclipse-zenoh/zenoh)
+        description: The branch to sync across all dependent repositories. Defaults to the default branch of the source repository (i.e. eclipse-zenoh/zenoh)
         required: false
       toolchain:
         type: string
-        description:
-          The rust toolchain to use. Defaults to 1.75.0
+        description: The rust toolchain to use. Defaults to 1.75.0
         required: false
 
 defaults:
@@ -50,7 +48,7 @@ jobs:
       - name: Install cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '3.31.x'
+          cmake-version: "3.31.x"
 
       - name: Install build dependencies
         run: sudo apt-get install -y llvm-dev libclang-dev clang libacl1-dev

--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -5,25 +5,21 @@ on:
     inputs:
       branch:
         type: string
-        description:
-          The branch to sync across all depedant repositories. Defaults to the default branch on each repository
+        description: The branch to sync across all depedant repositories. Defaults to the default branch on each repository
         required: false
       toolchain:
         type: string
-        description:
-          The rust toolchain to use. Defaults to 1.75.0
+        description: The rust toolchain to use. Defaults to 1.75.0
         required: false
   workflow_dispatch:
     inputs:
       branch:
         type: string
-        description:
-          The branch to sync across all depedant repositories. Defaults to the default branch on each repository
+        description: The branch to sync across all depedant repositories. Defaults to the default branch on each repository
         required: false
       toolchain:
         type: string
-        description:
-          The rust toolchain to use. Defaults to 1.75.0
+        description: The rust toolchain to use. Defaults to 1.75.0
         required: false
 
 defaults:
@@ -97,7 +93,7 @@ jobs:
       - name: Install cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '3.31.x'
+          cmake-version: "3.31.x"
 
       - name: Install build dependencies
         run: sudo apt-get install -y llvm-dev libclang-dev clang libacl1-dev
@@ -122,7 +118,6 @@ jobs:
           else
             echo "value=--all-features" >> $GITHUB_OUTPUT
           fi
-
 
       - name: Override ${{ matrix.dependant }} lockfile with Zenoh's
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Avoid polluting changelogs with automated sync and recreate entries

See: https://github.com/eclipse-zenoh/zenoh/releases/tag/1.7.1 or https://github.com/eclipse-zenoh/zenoh-backend-filesystem/releases/tag/1.7.1