### PR TITLE
chore: checkout github-sync using full SHA

### DIFF
--- a/.github/workflows/sync-milestones-labels.yml
+++ b/.github/workflows/sync-milestones-labels.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: pbochynski/github-sync
-          ref: 131ac0c
+          ref: 131ac0c6d4a7682b027fb570a421197ed316a5db
           path: github-sync
 
       - uses: actions/setup-node@v4
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: pbochynski/github-sync
-          ref: 131ac0c
+          ref: 131ac0c6d4a7682b027fb570a421197ed316a5db
           path: github-sync
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Fix https://github.com/eclipse-zenoh/ci/actions/runs/20754178882/job/59591471310#step:4:73