### PR TITLE
chore: fix checkout version tag

### DIFF
--- a/.github/workflows/update-latest-downloads.yml
+++ b/.github/workflows/update-latest-downloads.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@6.0.1
+        uses: actions/checkout@v6.0.1
 
       - name: Setup SSH key
         run: |


### PR DESCRIPTION
Fix https://github.com/eclipse-zenoh/ci/actions/runs/21627850140/job/62332515617