### PR TITLE
feat: add Eclipse ECA notification for PR contributors

### DIFF
--- a/.github/workflows/pr-eca-notify.yml
+++ b/.github/workflows/pr-eca-notify.yml
@@ -1,0 +1,228 @@
+name: PR ECA Notification
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      bot-authors:
+        description: "Comma-separated list of bot author usernames to skip"
+        required: false
+        type: string
+        default: "dependabot,eclipse-zenoh-bot"
+      eca-check-context:
+        description: "The context name of the ECA check status"
+        required: false
+        type: string
+        default: "eclipsefdn/eca"
+    secrets:
+      github-token:
+        required: true
+
+permissions:
+  pull-requests: write
+  statuses: read
+  contents: read
+
+env:
+  ECA_COMMENT_MARKER: "<!-- eclipse-eca-notification -->"
+
+jobs:
+  notify:
+    name: ECA notification
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Check if PR is from a bot
+        id: bot-check
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+            const botAuthors = '${{ inputs.bot-authors }}'.split(',').map(s => s.trim());
+            const isBot = pr.user.type === 'Bot' || botAuthors.includes(author);
+            console.log(`PR author: ${author}, isBot: ${isBot}`);
+            return isBot.toString();
+
+      - name: Skip for bot PRs
+        if: steps.bot-check.outputs.result == 'true'
+        run: |
+          echo "Skipping ECA notification for automated PR"
+          exit 0
+
+      - name: Check ECA status
+        if: steps.bot-check.outputs.result != 'true'
+        id: eca-check
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.github-token }}
+          script: |
+            const pr = context.payload.pull_request;
+            const sha = pr.head.sha;
+            const ecaContext = '${{ inputs.eca-check-context }}';
+
+            console.log(`Checking ECA status for SHA: ${sha}`);
+            console.log(`Looking for context: ${ecaContext}`);
+
+            // Get commit statuses
+            const { data: statuses } = await github.rest.repos.listCommitStatusesForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: sha,
+              per_page: 100
+            });
+
+            // Find the most recent ECA status
+            const ecaStatuses = statuses.filter(s => s.context === ecaContext);
+
+            if (ecaStatuses.length === 0) {
+              console.log('No ECA status found yet');
+              return JSON.stringify({ ecaFound: false, ecaState: 'pending', needsNotification: false });
+            }
+
+            // Get the most recent status (first in the list)
+            const latestEcaStatus = ecaStatuses[0];
+            console.log(`Latest ECA status: ${latestEcaStatus.state}`);
+            console.log(`Description: ${latestEcaStatus.description}`);
+
+            const needsNotification = latestEcaStatus.state === 'failure';
+
+            return JSON.stringify({
+              ecaFound: true,
+              ecaState: latestEcaStatus.state,
+              ecaDescription: latestEcaStatus.description,
+              ecaUrl: latestEcaStatus.target_url,
+              needsNotification: needsNotification
+            });
+
+      - name: Check for existing notification comment
+        if: steps.bot-check.outputs.result != 'true'
+        id: existing-comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.github-token }}
+          script: |
+            const marker = process.env.ECA_COMMENT_MARKER;
+            const prNumber = context.payload.pull_request.number;
+
+            // Get existing comments
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100
+            });
+
+            // Find our notification comment
+            const existingComment = comments.find(c => c.body.includes(marker));
+
+            if (existingComment) {
+              console.log(`Found existing ECA notification comment: ${existingComment.id}`);
+              return JSON.stringify({ found: true, commentId: existingComment.id });
+            }
+
+            console.log('No existing ECA notification comment found');
+            return JSON.stringify({ found: false, commentId: null });
+
+      - name: Post or update ECA notification comment
+        if: steps.bot-check.outputs.result != 'true'
+        uses: actions/github-script@v7
+        env:
+          ECA_RESULT: ${{ steps.eca-check.outputs.result }}
+          EXISTING_COMMENT: ${{ steps.existing-comment.outputs.result }}
+        with:
+          github-token: ${{ secrets.github-token }}
+          script: |
+            const ecaResult = JSON.parse(process.env.ECA_RESULT);
+            const existingComment = JSON.parse(process.env.EXISTING_COMMENT);
+            const marker = process.env.ECA_COMMENT_MARKER;
+            const prNumber = context.payload.pull_request.number;
+            const prAuthor = context.payload.pull_request.user.login;
+
+            // Build the ECA status URL
+            const ecaStatusUrl = `https://api.eclipse.org/git/eca/status/gh/${context.repo.owner}/${context.repo.repo}/${prNumber}`;
+            const ecaSignUrl = 'https://accounts.eclipse.org/user/eca';
+            const ecaFaqUrl = 'https://www.eclipse.org/legal/ecafaq.php';
+
+            if (ecaResult.needsNotification) {
+              // ECA check failed - create or update notification
+              const commentBody = `${marker}
+            ## Eclipse Contributor Agreement (ECA) Required
+
+            Hi @${prAuthor},
+
+            Thank you for your contribution! Before we can merge this pull request, you need to sign the **Eclipse Contributor Agreement (ECA)**.
+
+            ### What is the ECA?
+
+            The ECA is a legal agreement that ensures you have the rights to contribute your code and that you agree to license it under the project's open source license. This is required for all contributions to Eclipse Foundation projects.
+
+            ### How to sign the ECA:
+
+            1. **Create an Eclipse Foundation account** (if you don't have one): [Register here](https://accounts.eclipse.org/user/register)
+            2. **Sign the ECA**: [Sign here](${ecaSignUrl})
+            3. **Important**: Make sure the email address in your Eclipse account matches the email used in your Git commits
+
+            ### Verify your commit email:
+
+            Run this command in your local repository to check the email associated with your commits:
+            \`\`\`bash
+            git log --format='%ae' HEAD~1..HEAD
+            \`\`\`
+
+            If the email doesn't match your Eclipse account, you may need to:
+            - Add the email to your Eclipse account, or
+            - Amend your commits to use the correct email
+
+            ### More information:
+
+            - [ECA Validation Status](${ecaStatusUrl})
+            - [ECA FAQ](${ecaFaqUrl})
+
+            ---
+            *This comment was automatically generated. Once you've signed the ECA, push a new commit or re-run the ECA validation to update the status.*`;
+
+              if (existingComment.found) {
+                // Update existing comment
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existingComment.commentId,
+                  body: commentBody
+                });
+                console.log('Updated existing ECA notification comment');
+              } else {
+                // Create new comment
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: commentBody
+                });
+                console.log('Created new ECA notification comment');
+              }
+            } else if (ecaResult.ecaState === 'success' && existingComment.found) {
+              // ECA check passed - update the comment to reflect success
+              const successBody = `${marker}
+            ## Eclipse Contributor Agreement (ECA) - Signed
+
+            Thank you @${prAuthor}! Your Eclipse Contributor Agreement has been verified successfully.
+
+            ---
+            *This comment was automatically generated.*`;
+
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.commentId,
+                body: successBody
+              });
+              console.log('Updated ECA notification comment to show success');
+            } else {
+              console.log('No action needed - ECA status:', ecaResult.ecaState);
+            }

--- a/.github/workflows/pr-label-checklists-generate.yml
+++ b/.github/workflows/pr-label-checklists-generate.yml
@@ -8,15 +8,25 @@ on:
         type: string
         default: "ubuntu-latest"
       checklists-repo:
-        description: 'Repository containing pr-checklists.json'
+        description: "Repository containing pr-checklists.json"
         required: false
         type: string
         default: "eclipse-zenoh/ci"
       bot-authors:
-        description: 'Comma-separated list of bot author usernames to skip'
+        description: "Comma-separated list of bot author usernames to skip"
         required: false
         type: string
         default: "dependabot,eclipse-zenoh-bot"
+      enable-eca-notify:
+        description: "Enable Eclipse ECA notification for contributors who have not signed"
+        required: false
+        type: boolean
+        default: false
+      eca-check-context:
+        description: "The context name of the ECA check status"
+        required: false
+        type: string
+        default: "eclipsefdn/eca"
     secrets:
       github-token:
         required: true
@@ -27,8 +37,10 @@ permissions:
   contents: read
 
 env:
-  CHECKLIST_MARKER: '🏷️ Label-Based Checklist'
-  REQUIRED_LABELS: '["api-sync", "breaking-change", "bug", "ci", "dependencies", "documentation", "enhancement", "new feature", "internal"]'
+  CHECKLIST_MARKER: "🏷️ Label-Based Checklist"
+  REQUIRED_LABELS:
+    '["api-sync", "breaking-change", "bug", "ci", "dependencies", "documentation", "enhancement", "new feature",
+    "internal"]'
 
 jobs:
   main:
@@ -235,5 +247,16 @@ jobs:
     with:
       runner: ${{ inputs.runner }}
       bot-authors: ${{ inputs.bot-authors }}
+    secrets:
+      github-token: ${{ secrets.github-token }}
+
+  eca-notify:
+    needs: [main]
+    if: inputs.enable-eca-notify
+    uses: ./.github/workflows/pr-eca-notify.yml
+    with:
+      runner: ${{ inputs.runner }}
+      bot-authors: ${{ inputs.bot-authors }}
+      eca-check-context: ${{ inputs.eca-check-context }}
     secrets:
       github-token: ${{ secrets.github-token }}


### PR DESCRIPTION
## Summary

This PR adds a feature to notify PR authors when they haven't signed the Eclipse Contributor Agreement (ECA).

### Changes

- **New workflow `pr-eca-notify.yml`**: A reusable workflow that checks the ECA status and posts a helpful comment on the PR when ECA validation fails
- **Updated `pr-label-checklists-generate.yml`**: Added optional integration with the ECA notification workflow via the `enable-eca-notify` input

### Features

When the ECA check fails, the workflow posts a comment that includes:
- Explanation of what the ECA is and why it's required
- Step-by-step instructions to sign the ECA
- How to verify commit email matches Eclipse account
- Links to ECA validation status, sign page, and FAQ

When the ECA is successfully signed, the comment is updated to reflect the success.

### Usage

To enable ECA notification in a repository:

```yaml
jobs:
  pr-checks:
    uses: eclipse-zenoh/ci/.github/workflows/pr-label-checklists-generate.yml@main
    with:
      enable-eca-notify: true
    secrets:
      github-token: ${{ secrets.GITHUB_TOKEN }}
```

Or use standalone:

```yaml
jobs:
  eca-notify:
    uses: eclipse-zenoh/ci/.github/workflows/pr-eca-notify.yml@main
    secrets:
      github-token: ${{ secrets.GITHUB_TOKEN }}
```

### Related

This addresses the need to help contributors like in eclipse-zenoh/zenoh#2399 who submit PRs without having signed the ECA.