### PR TITLE
chore: sync-lockfiles use 1.93.0 by default

### DIFF
--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -125,11 +125,6 @@ jobs:
           name: Cargo.lock
           path: ${{ steps.crate-path.outputs.value }}
 
-      # Another ugly workaround, since zenoh-c has an additional Cargo.lock not in the root
-      - name: Override ${{ matrix.dependant }} build-resources lockfile with Zenoh's
-        if: ${{ matrix.dependant == 'eclipse-zenoh/zenoh-c' }}
-        run: cp Cargo.lock build-resources/opaque-types/Cargo.lock
-
       - name: Rectify lockfile
         # NOTE: Checking the package for errors will rectify the Cargo.lock while preserving
         # the dependency versions fetched from source.


### PR DESCRIPTION
- zenoh defaults to 1.93.0 so the sync-lockfiles requires this update since the change in https://github.com/eclipse-zenoh/zenoh/pull/2392
- removes the copying of the zenoh-c Cargo.lock to the opaque-types dir because when zenoh-c rectifies its lockfile, the build script copies it over to the opaque-types dir.

This should fix https://github.com/eclipse-zenoh/zenoh/actions/runs/22267474383/job/64416243684 and is related to https://github.com/eclipse-zenoh/zenoh/pull/2439