### PR TITLE
chore: bump toolchain for release

### DIFF
--- a/.github/workflows/merge-release-branch.yml
+++ b/.github/workflows/merge-release-branch.yml
@@ -49,7 +49,7 @@ jobs:
         if: ${{ !contains(fromJSON('["eclipse-zenoh/zenoh", "eclipse-zenoh/zenoh-pico", "eclipse-zenoh/zenoh-cpp", "eclipse-zenoh/zenoh-dissector"]'), matrix.repo) }}
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.75.0
+          toolchain: 1.93.0
 
       - name: Install dependencies for zenoh-dissector
         if: ${{ matrix.repo == 'eclipse-zenoh/zenoh-dissector' }}
@@ -68,7 +68,7 @@ jobs:
           release-branch: release/${{ inputs.version }}
           repo: ${{ matrix.repo }}
           github-token: ${{ secrets.BOT_TOKEN_WORKFLOW }}
-          toolchain: 1.85.0
+          toolchain: 1.93.0
           deps-pattern: zenoh.*
           deps-git-url: https://github.com/eclipse-zenoh/zenoh.git
           deps-branch: main

--- a/.github/workflows/recreate-lockfile.yml
+++ b/.github/workflows/recreate-lockfile.yml
@@ -11,7 +11,7 @@ on:
         required: false
       toolchain:
         type: string
-        description: The rust toolchain to use. Defaults to 1.75.0
+        description: The rust toolchain to use. Defaults to 1.93.0
         required: false
 
 defaults:
@@ -41,8 +41,8 @@ jobs:
         # NOTE: Showing the active Rust toolchain (defined by the rust-toolchain.toml file)
         # will have the side effect of installing it; if it's not installed already.
         run: |
-          rustup update ${{ inputs.toolchain || '1.75.0' }}
-          rustup component add --toolchain ${{ inputs.toolchain || '1.75.0'}} clippy
+          rustup update ${{ inputs.toolchain || '1.93.0' }}
+          rustup component add --toolchain ${{ inputs.toolchain || '1.93.0'}} clippy
 
       # cyclors does not compile with cmake 4
       - name: Install cmake
@@ -56,7 +56,7 @@ jobs:
       - name: Recreate Cargo.lock
         run: |
           rm -f Cargo.lock
-          cargo +${{ inputs.toolchain || '1.75.0' }} update --manifest-path Cargo.toml
+          cargo +${{ inputs.toolchain || '1.93.0' }} update --manifest-path Cargo.toml
 
       - name: Create/Update a pull request if the lockfile changed
         id: cpr

--- a/dist/bump-crates-main.mjs
+++ b/dist/bump-crates-main.mjs
@@ -63661,8 +63661,7 @@ function setup() {
     branch,
     repo,
     path: path === "" ? void 0 : path,
-    toolchain: toolchain === "" ? "1.75.0" : toolchain,
-    // Default to 1.75.0 to avoid updating Cargo.lock file version.
+    toolchain: toolchain === "" ? "1.93.0" : toolchain,
     tag,
     githubToken,
     bumpDepsPattern,

--- a/dist/set-git-branch-main.mjs
+++ b/dist/set-git-branch-main.mjs
@@ -63553,15 +63553,6 @@ async function setGitBranch(manifestPath, pattern, gitUrl, gitBranch) {
     }
   }
 }
-function setCargoLockVersion(cargoLockPath) {
-  core2.startGroup(`Setting Cargo.lock version`);
-  const record = toml.get(cargoLockPath, ["version"]);
-  if (record != void 0 && record["version"] != 3) {
-    const sedCommand = `sed -i.bak 's/^version = [[:digit:]]$/version = 3/' ${cargoLockPath}`;
-    sh(sedCommand);
-    sh(`rm -f ${cargoLockPath}.bak`);
-  }
-}
 async function installBinaryCached(name) {
   const env = { CARGO_REGISTRY_DEFAULT: "crates-io" };
   const version2 = config.lock.cratesio[name];
@@ -63595,8 +63586,7 @@ function setup() {
     releaseBranch,
     repo,
     path: path === "" ? void 0 : path,
-    toolchain: toolchain === "" ? "1.75.0" : toolchain,
-    // Default to 1.75.0 to avoid updating Cargo.lock file version.
+    toolchain: toolchain === "" ? "1.93.0" : toolchain,
     githubToken,
     githubUser: githubUser === "" ? "eclipse-zenoh-bot" : githubUser,
     depsRegExp: depsPattern === "" ? void 0 : new RegExp(depsPattern),
@@ -63612,14 +63602,6 @@ async function main(input) {
     sh(`git clone --recursive --single-branch --branch ${input.releaseBranch} ${remote}`);
     sh(`git switch -c ${input.githubUser}/post-release-${input.version}`, { cwd: repo });
     sh(`ls ${workspace}`);
-    const cargoLockPaths = sh(`find ${workspace} -name "Cargo.lock"`).split("\n").filter((r) => r);
-    for (const path2 of cargoLockPaths) {
-      setCargoLockVersion(path2);
-      if (sh("git diff", { cwd: repo, check: false })) {
-        sh("find . -name 'Cargo.lock' | xargs git add", { cwd: repo });
-        sh(`git commit --message 'chore: Update Cargo.lock version ${path2}'`, { cwd: repo, env: gitEnv });
-      }
-    }
     const cargoPaths = sh(`find ${workspace} -name "Cargo.toml*"`).split("\n").filter((r) => r);
     const pathsToCheck = [];
     let path;

--- a/dist/set-registry-main.mjs
+++ b/dist/set-registry-main.mjs
@@ -63575,8 +63575,7 @@ function setup() {
     releaseBranch,
     repo,
     path: path === "" ? void 0 : path,
-    toolchain: toolchain === "" ? "1.75.0" : toolchain,
-    // Default to 1.75.0 to avoid updating Cargo.lock file version.
+    toolchain: toolchain === "" ? "1.93.0" : toolchain,
     githubToken,
     depsRegExp: depsPattern === "" ? new RegExp("$^") : new RegExp(depsPattern)
   };

--- a/src/bump-crates.ts
+++ b/src/bump-crates.ts
@@ -59,7 +59,7 @@ export function setup(): Input {
     branch,
     repo,
     path: path === "" ? undefined : path,
-    toolchain: toolchain === "" ? "1.75.0" : toolchain, // Default to 1.75.0 to avoid updating Cargo.lock file version.
+    toolchain: toolchain === "" ? "1.93.0" : toolchain,
     tag,
     githubToken,
     bumpDepsPattern,

--- a/src/set-git-branch.ts
+++ b/src/set-git-branch.ts
@@ -37,7 +37,7 @@ export function setup(): Input {
     releaseBranch,
     repo,
     path: path === "" ? undefined : path,
-    toolchain: toolchain === "" ? "1.75.0" : toolchain, // Default to 1.75.0 to avoid updating Cargo.lock file version.
+    toolchain: toolchain === "" ? "1.93.0" : toolchain,
     githubToken,
     githubUser: githubUser === "" ? "eclipse-zenoh-bot" : githubUser,
     depsRegExp: depsPattern === "" ? undefined : new RegExp(depsPattern),
@@ -55,17 +55,6 @@ export async function main(input: Input) {
     sh(`git clone --recursive --single-branch --branch ${input.releaseBranch} ${remote}`);
     sh(`git switch -c ${input.githubUser}/post-release-${input.version}`, { cwd: repo });
     sh(`ls ${workspace}`);
-    // Correct Cargo.lock version to 1.75 toolchain compatible version
-    const cargoLockPaths = sh(`find ${workspace} -name "Cargo.lock"`)
-      .split("\n")
-      .filter(r => r);
-    for (const path of cargoLockPaths) {
-      cargo.setCargoLockVersion(path);
-      if (sh("git diff", { cwd: repo, check: false })) {
-        sh("find . -name 'Cargo.lock' | xargs git add", { cwd: repo });
-        sh(`git commit --message 'chore: Update Cargo.lock version ${path}'`, { cwd: repo, env: gitEnv });
-      }
-    }
     // find all Cargo.toml files in the workspace, filtering out the empty string from the array
     const cargoPaths = sh(`find ${workspace} -name "Cargo.toml*"`)
       .split("\n")

--- a/src/set-registry.ts
+++ b/src/set-registry.ts
@@ -43,7 +43,7 @@ export function setup(): Input {
     releaseBranch,
     repo,
     path: path === "" ? undefined : path,
-    toolchain: toolchain === "" ? "1.75.0" : toolchain, // Default to 1.75.0 to avoid updating Cargo.lock file version.
+    toolchain: toolchain === "" ? "1.93.0" : toolchain,
     githubToken,
     depsRegExp: depsPattern === "" ? new RegExp("$^") : new RegExp(depsPattern),
   };


### PR DESCRIPTION
Since https://github.com/eclipse-zenoh/zenoh/pull/2392 zenoh and dependants don't rely on the 1.75.0 toolchain anymore.

This updates the default toolchain in the ci workflows so we can make the new 1.8.0 release

Fix https://github.com/eclipse-zenoh/zenoh/actions/runs/22556085740/job/65333584926