### PR TITLE
chore: use ZettaScaleLabs fork with updated deps

### DIFF
--- a/.github/workflows/sync-milestones-labels.yml
+++ b/.github/workflows/sync-milestones-labels.yml
@@ -126,8 +126,8 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          repository: pbochynski/github-sync
-          ref: 131ac0c6d4a7682b027fb570a421197ed316a5db
+          repository: ZettaScaleLabs/github-sync
+          ref: main
           path: github-sync
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Update `github-sync` dependency to use https://github.com/zettascalelabs/github-sync which in turn updates the `@octokit/rest` and `yargs` dependencies to their latest versions

Hopefully fixes https://github.com/eclipse-zenoh/ci/actions/runs/22758179388/job/66007901568

Initially I thought we were being rate limited but after reading the github docs and the returned headers in the POST request, we should have plenty of requests avaialble.
```
'x-ratelimit-limit': '5000',
'x-ratelimit-remaining': '4988',
'x-ratelimit-reset': '1772794265',
'x-ratelimit-resource': 'core',
'x-ratelimit-used': '12',
```