### PR TITLE
fix: udpate eclipse dash license tool download url

### DIFF
--- a/.github/workflows/eclipse-ipddp.yml
+++ b/.github/workflows/eclipse-ipddp.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Download Eclipse IPDDP License Tool
         run: |
-          wget "https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST" -O org.eclipse.dash.licenses-latest.jar
+          wget "https://repo.eclipse.org/service/rest/v1/search/assets/download?repository=dash-maven2-releases&maven.groupId=org.eclipse.dash&maven.artifactId=org.eclipse.dash.licenses&maven.baseVersion=1.1.0&maven.extension=jar" -O org.eclipse.dash.licenses-latest.jar
 
       - name: Run Eclipse IPDDP License Tool
         run: |


### PR DESCRIPTION
See https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/7263, the new nexus endpoint will not be supported by the EF infra team.