### PR TITLE
fix: set-git-branch consider only Cargo.toml

### DIFF
--- a/dist/set-git-branch-main.mjs
+++ b/dist/set-git-branch-main.mjs
@@ -63602,7 +63602,7 @@ async function main(input) {
     sh(`git clone --recursive --single-branch --branch ${input.releaseBranch} ${remote}`);
     sh(`git switch -c ${input.githubUser}/post-release-${input.version}`, { cwd: repo });
     sh(`ls ${workspace}`);
-    const cargoPaths = sh(`find ${workspace} -name "Cargo.toml*"`).split("\n").filter((r) => r);
+    const cargoPaths = sh(`find ${workspace} -name "Cargo.toml"`).split("\n").filter((r) => r);
     const pathsToCheck = [];
     let path;
     for (path of cargoPaths) {

--- a/src/set-git-branch.ts
+++ b/src/set-git-branch.ts
@@ -56,7 +56,7 @@ export async function main(input: Input) {
     sh(`git switch -c ${input.githubUser}/post-release-${input.version}`, { cwd: repo });
     sh(`ls ${workspace}`);
     // find all Cargo.toml files in the workspace, filtering out the empty string from the array
-    const cargoPaths = sh(`find ${workspace} -name "Cargo.toml*"`)
+    const cargoPaths = sh(`find ${workspace} -name "Cargo.toml"`)
       .split("\n")
       .filter(r => r);
 


### PR DESCRIPTION
In https://github.com/eclipse-zenoh/ci/pull/445 set-git-branch was fixed to only consider Cargo.toml files and skip zenoh-c's Cargo.toml.in but missed the glob in previous find call that builds the cargoPaths.

Should fix https://github.com/eclipse-zenoh/ci/actions/runs/24405301060/job/71286854874