### PR TITLE
fix: update bump-crates to handle non-versioned dep

### DIFF
--- a/__tests__/cargo.test.ts
+++ b/__tests__/cargo.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "@jest/globals";
 import { join } from "path";
 import { rm } from "fs/promises";
 import { tmpdir } from "os";
-import { mkdtemp, realpath } from "fs/promises";
+import { mkdir, mkdtemp, writeFile, realpath } from "fs/promises";
 import { createWriteStream, rmSync } from "fs";
 import * as https from "https";
 
@@ -13,7 +13,7 @@ import { TOML } from "../src/toml";
 
 const toml = await TOML.init();
 
-const SHA_ZENOH: string = "9ecc9031ac34f6ae0f8e5b996999277b02b3038e";
+const SHA_ZENOH: string = "a6d75a06abaa4d97de02eb8e89cee330b21a0447";
 const SHA_ZENOH_C: string = "ffa4bddc947f7ed6c0e3b4546205dd1b73e7df81";
 const SHA_ZENOH_TS: string = "d0ee49fd8ccb4016d90b03be431de4c3cb087bdd";
 const SHA_ZENOH_KOTLIN: string = "6ba9cf6e058c959614bd7f1f4148e8fa39ef1681";
@@ -121,17 +121,60 @@ describe("cargo", () => {
     expect(toml.get(`${path}/Cargo.toml`, ["dependencies", "zenoh-ext", "version"])).toEqual(version);
   });
 
-  test("bump deps zenoh", async () => {
-    const tmp = await downloadGitHubRepo("eclipse-zenoh/zenoh", SHA_ZENOH);
+  test(
+    "bump deps zenoh",
+    async () => {
+      const tmp = await downloadGitHubRepo("eclipse-zenoh/zenoh", SHA_ZENOH);
 
-    const version = "1.2.3-beta.1";
-    const debian_version = "1.2.3~beta.1-1";
-    await cargo.bumpDependencies(tmp, /zenoh.*/, version);
+      const version = "1.2.3-beta.1";
+      const debian_version = "1.2.3~beta.1-1";
+      await cargo.bumpDependencies(tmp, /zenoh.*/, version);
 
-    expect(toml.get(`${tmp}/Cargo.toml`, ["workspace", "dependencies", "zenoh", "version"])).toEqual(version);
-    expect(toml.get(`${tmp}/zenoh/Cargo.toml`, ["package", "metadata", "deb", "depends"])).toEqual(
-      `zenohd (=${debian_version}), zenoh-plugin-rest (=${debian_version}), zenoh-plugin-storage-manager (=${debian_version})`,
+      // zenoh versions are pinned with "=", so we expect the bumped version to be pinned as well
+      expect(toml.get(`${tmp}/Cargo.toml`, ["workspace", "dependencies", "zenoh", "version"])).toEqual(`=${version}`);
+      expect(toml.get(`${tmp}/zenoh/Cargo.toml`, ["package", "metadata", "deb", "depends"])).toEqual(
+        `zenohd (=${debian_version}), zenoh-plugin-rest (=${debian_version}), zenoh-plugin-storage-manager (=${debian_version})`,
+      );
+    },
+    60 * SECONDS,
+  );
+
+  test("bump deps handles string, pinned, and non-versioned dependency forms", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "cargo-bump-deps-"));
+    const manifestPath = join(tmp, "Cargo.toml");
+
+    await mkdir(join(tmp, "src"), { recursive: true });
+    await mkdir(join(tmp, "commons", "zenoh-test", "src"), { recursive: true });
+    await writeFile(
+      manifestPath,
+      `
+  [package]
+  name = "test-crate"
+  version = "0.1.0"
+  edition = "2021"
+  [dependencies]
+  zenoh = "=1.0.0"
+  zenoh-ext = "1.0.0"
+  zenoh-test = { path = "commons/zenoh-test" }
+  `,
     );
+    await writeFile(join(tmp, "src", "lib.rs"), "pub fn test_crate() {}\n");
+    await writeFile(
+      join(tmp, "commons", "zenoh-test", "Cargo.toml"),
+      `
+  [package]
+  name = "zenoh-test"
+  version = "0.1.0"
+  edition = "2021"
+  [lib]
+  path = "src/lib.rs"
+  `,
+    );
+    await writeFile(join(tmp, "commons", "zenoh-test", "src", "lib.rs"), "pub fn zenoh_test() {}\n");
+    await cargo.bumpDependencies(tmp, /zenoh.*/, "1.2.3-beta.1");
+    expect(toml.get(manifestPath, ["dependencies", "zenoh", "version"])).toEqual("=1.2.3-beta.1");
+    expect(toml.get(manifestPath, ["dependencies", "zenoh-ext", "version"])).toEqual("1.2.3-beta.1");
+    expect(toml.get(manifestPath, ["dependencies", "zenoh-test", "version"])).toBeNull();
   });
 
   test("toDebianVersion()", async () => {

--- a/dist/bump-crates-main.mjs
+++ b/dist/bump-crates-main.mjs
@@ -71653,9 +71653,14 @@ async function bumpDependencies(path2, pattern, version, _branch) {
   for (const dep in manifest.dependencies) {
     if (pattern.test(dep)) {
       const d = manifest.dependencies[dep];
-      let depVersion = version;
-      if (d.version.startsWith("=")) {
-        depVersion = "=" + version;
+      let depVersion;
+      if (typeof d === "string") {
+        depVersion = d.startsWith("=") ? `=${version}` : version;
+      } else if (typeof d === "object" && d !== null && typeof d.version === "string") {
+        depVersion = d.version.startsWith("=") ? `=${version}` : version;
+      } else {
+        core2.info(`Skipping ${dep}: no version field to bump`);
+        continue;
       }
       await toml.set(manifestPath, prefix.concat("dependencies", dep, "version"), depVersion);
       await toml.unset(manifestPath, prefix.concat("dependencies", dep, "git"));

--- a/src/cargo.ts
+++ b/src/cargo.ts
@@ -109,7 +109,9 @@ type CargoManifestMetadataDebianVariant = {
 };
 
 type CargoManifestDependencyTable = {
-  version: string;
+  version?: string;
+  path?: string;
+  workspace?: boolean;
   git?: string;
   branch?: string;
   registry?: string;
@@ -162,8 +164,8 @@ export async function bump(path: string, version: string) {
  * virtual manifest from which all workspace members inherit their dependencies
  * (e.g. eclipse-zenoh/zenoh and eclipse-zenoh/zenoh-plugin-influxdb), or (2) a
  * manifest without a workspace section with only one member (e.g.
- * eclipse-zenoh/zenoh-plugin-webserver). It also assumes that all matching
- * dependencies define a version, a git repository remote and a git branch.
+ * eclipse-zenoh/zenoh-plugin-webserver). It only bumps matching
+ * dependencies that define a version, a git repository remote and a git branch.
  *
  * @param path Path to the Cargo workspace.
  * @param pattern A regular expression that matches the dependencies to be
@@ -189,12 +191,19 @@ export async function bumpDependencies(path: string, pattern: RegExp, version: s
 
   for (const dep in manifest.dependencies) {
     if (pattern.test(dep)) {
+      const d = manifest.dependencies[dep];
+      let depVersion: string;
+
       // Respect the pins if they exist in the dependency
-      const d = manifest.dependencies[dep] as CargoManifestDependencyTable;
-      let depVersion = version;
-      if (d.version.startsWith("=")) {
-        depVersion = "=" + version;
+      if (typeof d === "string") {
+        depVersion = d.startsWith("=") ? `=${version}` : version;
+      } else if (typeof d === "object" && d !== null && typeof d.version === "string") {
+        depVersion = d.version.startsWith("=") ? `=${version}` : version;
+      } else {
+        core.info(`Skipping ${dep}: no version field to bump`);
+        continue;
       }
+
       await toml.set(manifestPath, prefix.concat("dependencies", dep, "version"), depVersion);
 
       // FIXME(fuzzypixelz): Previously, we set the branch of the git source in dependencies,


### PR DESCRIPTION
Handles the case of zenoh-test workspace only dependency which doesn't define a version and should be skipped by bumpDependencies.

See https://github.com/eclipse-zenoh/zenoh/actions/runs/26483044501/job/77984341817