### PR TITLE
chore: update node in actions.yml and alias tsup banner

### DIFF
--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version-file: .node-version
 
-      - uses: taiki-e/cache-cargo-install-action@v2
+      - uses: taiki-e/cache-cargo-install-action@v3
         with:
           tool: toml-cli2
 

--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -8,9 +8,9 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
 

--- a/build-crates-debian/action.yml
+++ b/build-crates-debian/action.yml
@@ -17,5 +17,5 @@ outputs:
     description: Artifact id
 
 runs:
-  using: node20
+  using: node24
   main: ../dist/build-crates-debian-main.mjs

--- a/build-crates-standalone/action.yml
+++ b/build-crates-standalone/action.yml
@@ -21,5 +21,5 @@ outputs:
     description: Artifact name
 
 runs:
-  using: node20
+  using: node24
   main: ../dist/build-crates-standalone-main.mjs

--- a/bump-crates/action.yml
+++ b/bump-crates/action.yml
@@ -27,5 +27,5 @@ inputs:
     required: false
 
 runs:
-  using: node20
+  using: node24
   main: ../dist/bump-crates-main.mjs

--- a/create-release-branch/action.yml
+++ b/create-release-branch/action.yml
@@ -23,5 +23,5 @@ outputs:
     description: Release branch
 
 runs:
-  using: node20
+  using: node24
   main: ../dist/create-release-branch-main.mjs

--- a/dist/build-crates-debian-main.mjs
+++ b/dist/build-crates-debian-main.mjs
@@ -1,4 +1,3 @@
-import { createRequire } from 'module'; const require = createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/build-crates-debian-main.mjs
+++ b/dist/build-crates-debian-main.mjs
@@ -1,3 +1,4 @@
+import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/build-crates-standalone-main.mjs
+++ b/dist/build-crates-standalone-main.mjs
@@ -1,4 +1,3 @@
-import { createRequire } from 'module'; const require = createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/build-crates-standalone-main.mjs
+++ b/dist/build-crates-standalone-main.mjs
@@ -1,3 +1,4 @@
+import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/bump-crates-main.mjs
+++ b/dist/bump-crates-main.mjs
@@ -1,4 +1,3 @@
-import { createRequire } from 'module'; const require = createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/bump-crates-main.mjs
+++ b/dist/bump-crates-main.mjs
@@ -1,3 +1,4 @@
+import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/create-release-branch-main.mjs
+++ b/dist/create-release-branch-main.mjs
@@ -1,4 +1,3 @@
-import { createRequire } from 'module'; const require = createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/create-release-branch-main.mjs
+++ b/dist/create-release-branch-main.mjs
@@ -1,3 +1,4 @@
+import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/publish-crates-cargo-main.mjs
+++ b/dist/publish-crates-cargo-main.mjs
@@ -1,4 +1,3 @@
-import { createRequire } from 'module'; const require = createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/publish-crates-cargo-main.mjs
+++ b/dist/publish-crates-cargo-main.mjs
@@ -1,3 +1,4 @@
+import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/publish-crates-debian-main.mjs
+++ b/dist/publish-crates-debian-main.mjs
@@ -1,4 +1,3 @@
-import { createRequire } from 'module'; const require = createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/publish-crates-debian-main.mjs
+++ b/dist/publish-crates-debian-main.mjs
@@ -1,3 +1,4 @@
+import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/publish-crates-eclipse-main.mjs
+++ b/dist/publish-crates-eclipse-main.mjs
@@ -1,4 +1,3 @@
-import { createRequire } from 'module'; const require = createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/publish-crates-eclipse-main.mjs
+++ b/dist/publish-crates-eclipse-main.mjs
@@ -1,3 +1,4 @@
+import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/publish-crates-github-main.mjs
+++ b/dist/publish-crates-github-main.mjs
@@ -1,4 +1,3 @@
-import { createRequire } from 'module'; const require = createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/publish-crates-github-main.mjs
+++ b/dist/publish-crates-github-main.mjs
@@ -1,3 +1,4 @@
+import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/publish-crates-homebrew-main.mjs
+++ b/dist/publish-crates-homebrew-main.mjs
@@ -1,4 +1,3 @@
-import { createRequire } from 'module'; const require = createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/publish-crates-homebrew-main.mjs
+++ b/dist/publish-crates-homebrew-main.mjs
@@ -1,3 +1,4 @@
+import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/set-git-branch-main.mjs
+++ b/dist/set-git-branch-main.mjs
@@ -1,4 +1,3 @@
-import { createRequire } from 'module'; const require = createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/set-git-branch-main.mjs
+++ b/dist/set-git-branch-main.mjs
@@ -1,3 +1,4 @@
+import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/set-registry-main.mjs
+++ b/dist/set-registry-main.mjs
@@ -1,4 +1,3 @@
-import { createRequire } from 'module'; const require = createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/set-registry-main.mjs
+++ b/dist/set-registry-main.mjs
@@ -1,3 +1,4 @@
+import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/publish-crates-cargo/action.yml
+++ b/publish-crates-cargo/action.yml
@@ -25,5 +25,5 @@ inputs:
     required: false
 
 runs:
-  using: node20
+  using: node24
   main: ../dist/publish-crates-cargo-main.mjs

--- a/publish-crates-debian/action.yml
+++ b/publish-crates-debian/action.yml
@@ -23,5 +23,5 @@ inputs:
     required: true
 
 runs:
-  using: node20
+  using: node24
   main: ../dist/publish-crates-debian-main.mjs

--- a/publish-crates-eclipse/action.yml
+++ b/publish-crates-eclipse/action.yml
@@ -17,5 +17,5 @@ inputs:
     required: false
 
 runs:
-  using: node20
+  using: node24
   main: ../dist/publish-crates-eclipse-main.mjs

--- a/publish-crates-github/action.yml
+++ b/publish-crates-github/action.yml
@@ -15,5 +15,5 @@ inputs:
     required: false
 
 runs:
-  using: node20
+  using: node24
   main: ../dist/publish-crates-github-main.mjs

--- a/publish-crates-homebrew/action.yml
+++ b/publish-crates-homebrew/action.yml
@@ -25,5 +25,5 @@ inputs:
     required: true
 
 runs:
-  using: node20
+  using: node24
   main: ../dist/publish-crates-homebrew-main.mjs

--- a/set-git-branch/action.yml
+++ b/set-git-branch/action.yml
@@ -23,5 +23,5 @@ inputs:
   deps-branch:
     required: true
 runs:
-  using: node20
+  using: node24
   main: ../dist/set-git-branch-main.mjs

--- a/set-registry/action.yml
+++ b/set-registry/action.yml
@@ -24,5 +24,5 @@ inputs:
   toolchain:
     required: false
 runs:
-  using: node20
+  using: node24
   main: ../dist/set-registry-main.mjs

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import _config from "../ci.config.json";
+import _config from "../ci.config.json" with { type: "json" };
 
 type Config = {
   git: {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -13,9 +13,6 @@ export default defineConfig({
     target: "es2022",
     format: 'esm',
     outDir: "dist/",
-    banner: {
-        js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,
-    },
     outExtension({ format }) {
         return {
             js: `.mjs`,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
     target: "es2022",
     format: 'esm',
     outDir: "dist/",
+    banner: {
+        js: `import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);`,
+    },
     outExtension({ format }) {
         return {
             js: `.mjs`,


### PR DESCRIPTION
- update actions.yml to use node24
- alias the tsup banner to avoid conflict with existing createRequire from other dependencies
- fix jest deprecation warning when running `npm run test`
- update _ci.yml to use latest checkout, setup-node and cache-cargo-install versions

Should fix https://github.com/eclipse-zenoh/zenoh-pico/actions/runs/28173246318/job/83442707659?pr=1250