### PR TITLE
fix: add brew trust to homebrew publication

### DIFF
--- a/build-crates-debian/action.yml
+++ b/build-crates-debian/action.yml
@@ -1,4 +1,5 @@
 name: Build crates (Debian)
+description: Build Debian packaging
 
 inputs:
   repo:

--- a/build-crates-standalone/action.yml
+++ b/build-crates-standalone/action.yml
@@ -1,4 +1,5 @@
 name: Build crates (Standalone)
+description: Build standalone artifacts
 
 inputs:
   repo:

--- a/bump-crates/action.yml
+++ b/bump-crates/action.yml
@@ -1,4 +1,5 @@
 name: Bump crates
+description: Bump crates versions and dependencies
 
 inputs:
   version:

--- a/create-release-branch/action.yml
+++ b/create-release-branch/action.yml
@@ -1,4 +1,5 @@
 name: Create release branch
+description: Create a release branch for the given version
 
 inputs:
   version:

--- a/dist/publish-crates-homebrew-main.mjs
+++ b/dist/publish-crates-homebrew-main.mjs
@@ -105358,6 +105358,9 @@ var X86_64_SHA256 = "x86_64-sha256";
 async function main(input) {
   try {
     const repo = input.repo.split("/").at(1);
+    if (repo === void 0) {
+      throw new Error(`Invalid repo format: ${input.repo}`);
+    }
     const tapPath = `${sh("brew --repository").trim()}/Library/Taps/${input.tap}`;
     const tapUrl = `https://${input.githubToken}@github.com/${input.tap}.git`;
     for (const target of [X86_64_APPLE_DARWIN, AARCH64_APPLE_DARWIN]) {

--- a/dist/publish-crates-homebrew-main.mjs
+++ b/dist/publish-crates-homebrew-main.mjs
@@ -105373,6 +105373,7 @@ async function main(input) {
     }
     sh(`brew untap ${input.tap}`, { check: false });
     sh(`brew tap ${input.tap} ${tapUrl}`);
+    sh(`brew trust ${input.tap}`);
     const releasePath = `${tapPath}/release.json`;
     const releaseFile = await fs14.readFile(releasePath, "utf-8");
     const release2 = JSON.parse(releaseFile);

--- a/publish-crates-cargo/action.yml
+++ b/publish-crates-cargo/action.yml
@@ -1,4 +1,5 @@
 name: Publish crates (Cargo)
+description: Publish crates to crates.io and/or Artifactory
 
 inputs:
   live-run:

--- a/publish-crates-debian/action.yml
+++ b/publish-crates-debian/action.yml
@@ -1,4 +1,5 @@
 name: Publish crates (Debian)
+description: Publish to Debian repository
 
 inputs:
   live-run:

--- a/publish-crates-eclipse/action.yml
+++ b/publish-crates-eclipse/action.yml
@@ -1,4 +1,5 @@
 name: Publish crates (Eclipse)
+description: Publish to Eclipse repository
 
 inputs:
   live-run:

--- a/publish-crates-github/action.yml
+++ b/publish-crates-github/action.yml
@@ -1,4 +1,5 @@
 name: Publish crates (GitHub)
+description: Publish artifacts to GitHub release
 
 inputs:
   live-run:

--- a/publish-crates-homebrew/action.yml
+++ b/publish-crates-homebrew/action.yml
@@ -1,4 +1,5 @@
 name: Publish crates (Homebrew)
+description: Publish to Homebrew repository
 
 inputs:
   live-run:

--- a/set-git-branch/action.yml
+++ b/set-git-branch/action.yml
@@ -1,4 +1,5 @@
 name: Set git branch
+description: Set git branch for dependencies
 
 inputs:
   version:

--- a/set-registry/action.yml
+++ b/set-registry/action.yml
@@ -1,4 +1,5 @@
 name: Set registry
+description: Set registry for dependencies
 
 inputs:
   version:

--- a/src/publish-crates-homebrew.ts
+++ b/src/publish-crates-homebrew.ts
@@ -74,6 +74,9 @@ type Release = {
 export async function main(input: Input) {
   try {
     const repo = input.repo.split("/").at(1);
+    if (repo === undefined) {
+      throw new Error(`Invalid repo format: ${input.repo}`);
+    }
     const tapPath = `${sh("brew --repository").trim()}/Library/Taps/${input.tap}`;
     const tapUrl = `https://${input.githubToken}@github.com/${input.tap}.git`;
 

--- a/src/publish-crates-homebrew.ts
+++ b/src/publish-crates-homebrew.ts
@@ -92,6 +92,7 @@ export async function main(input: Input) {
 
     sh(`brew untap ${input.tap}`, { check: false });
     sh(`brew tap ${input.tap} ${tapUrl}`);
+    sh(`brew trust ${input.tap}`);
 
     const releasePath = `${tapPath}/release.json`;
     const releaseFile = await fs.readFile(releasePath, "utf-8");


### PR DESCRIPTION
I believe this is related to the update to GH hosted runners to use Tahoe (macos-26). [Previously](https://github.com/eclipse-zenoh/zenoh/actions/runs/27922492826/job/82620139745#step:1:12), on macos-15, the same workflow worked without needing to trust the tap. Both runners still use Homebrew 5.1.15 so maybe only on Tahoe they enabled the env var `HOMEBREW_REQUIRE_TAP_TRUST` but I couldn't find any evidence of in https://github.com/actions/runner-images.  

Should fix: https://github.com/eclipse-zenoh/zenoh/actions/runs/28209201247/job/83569299811

Additionally, I added descriptions to the actions.yml and a undefined guard to `publish-crates-homebrew.ts` to address some VSCode warnings.