### PR TITLE
chore: update sync-toolchains.yml workflow

### DIFF
--- a/.github/workflows/sync-toolchains.yml
+++ b/.github/workflows/sync-toolchains.yml
@@ -30,7 +30,6 @@ jobs:
           - zenoh-kotlin
           - zenoh-plugin-dds
           - zenoh-plugin-mqtt
-          - zenoh-plugin-ros1
           - zenoh-plugin-ros2dds
           - zenoh-plugin-webserver
           - zenoh-backend-filesystem
@@ -41,7 +40,7 @@ jobs:
           - zenoh-dissector
     steps:
       - name: Clone ${{ matrix.dependant }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: eclipse-zenoh/${{ matrix.dependant }}
           ref: ${{ inputs.branch }}
@@ -53,7 +52,7 @@ jobs:
       - name: Create/Update a pull request if the toolchain changed
         id: cpr
         # NOTE: If there is a pending PR, this action will simply update it with a forced push.
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           title: Sync Rust toolchain
           body: >


### PR DESCRIPTION
- remove deprecated zenoh-plugin-ros1
- update actions@checkout to v7.0.0
- update peter-evans/create-pull-request to v8.1.1
- Use SHA pinning for immutable actions code