### PR TITLE
chore: update sync-lockfiles.yml to use rust-toolchain channel value

### DIFF
--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -84,15 +84,30 @@ jobs:
 
       - id: toolchain
         name: Get Rust toolchain
+        env:
+          TOOLCHAIN_INPUT: ${{ inputs.toolchain }}
         run: |
-          echo "rust-toolchain=$(cat rust-toolchain.toml | grep channel | cut -d'"' -f2)" >> $GITHUB_OUTPUT
+          set -euo pipefail
+
+          if [[ -n "$TOOLCHAIN_INPUT" ]]; then
+            RUST_TOOLCHAIN="$TOOLCHAIN_INPUT"
+          else
+            RUST_TOOLCHAIN="$(yq -r '.toolchain.channel // ""' rust-toolchain.toml)"
+          fi
+
+          if [[ ! "$RUST_TOOLCHAIN" =~ ^[A-Za-z0-9][A-Za-z0-9._+@-]*$ ]]; then
+            echo "Invalid Rust toolchain" >&2
+            exit 1
+          fi
+
+          printf 'RUST_TOOLCHAIN=%s\n' "$RUST_TOOLCHAIN" >> "$GITHUB_ENV"
 
       - name: Install Rust toolchain
         # NOTE: Showing the active Rust toolchain (defined by the rust-toolchain.toml file)
         # will have the side effect of installing it; if it's not installed already.
         run: |
-          rustup update ${{ inputs.toolchain || steps.toolchain.outputs.rust-toolchain }}
-          rustup component add --toolchain ${{ inputs.toolchain || steps.toolchain.outputs.rust-toolchain }} clippy
+          rustup update "${RUST_TOOLCHAIN}"
+          rustup component add --toolchain "${RUST_TOOLCHAIN}" clippy
 
       - name: Install build dependencies
         run: sudo apt-get install -y llvm-dev libclang-dev clang libacl1-dev
@@ -127,21 +142,21 @@ jobs:
       - name: Rectify lockfile
         # NOTE: Checking the package for errors will rectify the Cargo.lock while preserving
         # the dependency versions fetched from source.
-        run: cargo +${{ inputs.toolchain || steps.toolchain.outputs.rust-toolchain }} clippy --manifest-path ${{ steps.crate-path.outputs.value }}/Cargo.toml  --all-targets ${{ steps.clippy-options.outputs.value }} -- --deny warnings
+        run: cargo "+${RUST_TOOLCHAIN}" clippy --manifest-path ${{ steps.crate-path.outputs.value }}/Cargo.toml  --all-targets ${{ steps.clippy-options.outputs.value }} -- --deny warnings
 
       - name: Rectify lockfile for zenoh-c opaque-types
         if: ${{ matrix.dependant == 'eclipse-zenoh/zenoh-c' }}
         # Disable panic feature for zenoh-c opaque-types
         run: |
           features=$(cargo tree --manifest-path build-resources/opaque-types/Cargo.toml -f "{p} {f}" --all-features| grep opaque-types | cut -d" " -f4 | sed s/panic,//)
-          cargo +${{ inputs.toolchain || steps.toolchain.outputs.rust-toolchain }} clippy --manifest-path build-resources/opaque-types/Cargo.toml --all-targets --features $features -- --deny warnings
+          cargo "+${RUST_TOOLCHAIN}" clippy --manifest-path build-resources/opaque-types/Cargo.toml --all-targets --features $features -- --deny warnings
 
       - name: cargo update ${{ matrix.dependant }}
-        run: cargo +${{ inputs.toolchain || steps.toolchain.outputs.rust-toolchain }} update zenoh --manifest-path ${{ steps.crate-path.outputs.value }}/Cargo.toml
+        run: cargo "+${RUST_TOOLCHAIN}" update zenoh --manifest-path ${{ steps.crate-path.outputs.value }}/Cargo.toml
 
       - name: cargo update for zenoh-c build-resources
         if: ${{ matrix.dependant == 'eclipse-zenoh/zenoh-c' }}
-        run: cargo +${{ inputs.toolchain || steps.toolchain.outputs.rust-toolchain }} update zenoh --manifest-path build-resources/opaque-types/Cargo.toml
+        run: cargo "+${RUST_TOOLCHAIN}" update zenoh --manifest-path build-resources/opaque-types/Cargo.toml
 
       - name: Create/Update a pull request if the lockfile changed
         id: cpr

--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -35,7 +35,7 @@ jobs:
       zenoh-head-date: ${{ steps.info.outputs.head-date }}
     steps:
       - name: Checkout Zenoh
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: eclipse-zenoh/zenoh
           ref: ${{ inputs.branch }}
@@ -47,7 +47,7 @@ jobs:
           echo "head-date=$(git log -1 --format=%as)" >> $GITHUB_OUTPUT
 
       - name: Upload lockfile
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Cargo.lock
           path: Cargo.lock
@@ -75,7 +75,7 @@ jobs:
           - eclipse-zenoh/zenoh-ts
     steps:
       - name: Checkout ${{ matrix.dependant }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ matrix.dependant }}
           ref: ${{ inputs.branch }}
@@ -120,7 +120,7 @@ jobs:
           fi
 
       - name: Override ${{ matrix.dependant }} lockfile with Zenoh's
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Cargo.lock
           path: ${{ steps.crate-path.outputs.value }}
@@ -147,7 +147,7 @@ jobs:
       - name: Create/Update a pull request if the lockfile changed
         id: cpr
         # NOTE: If there is a pending PR, this action will simply update it with a forced push.
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           title: Sync `Cargo.lock` with Zenoh `${{ needs.fetch.outputs.zenoh-head-hash }}` from `${{needs.fetch.outputs.zenoh-head-date }}`
           body: |

--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -5,21 +5,21 @@ on:
     inputs:
       branch:
         type: string
-        description: The branch to sync across all depedant repositories. Defaults to the default branch on each repository
+        description: The branch to sync across all dependant repositories. Defaults to the default branch on each repository
         required: false
       toolchain:
         type: string
-        description: The rust toolchain to use. Defaults to 1.93.0
+        description: The rust toolchain to use. Defaults to rust-toolchain.toml's channel value
         required: false
   workflow_dispatch:
     inputs:
       branch:
         type: string
-        description: The branch to sync across all depedant repositories. Defaults to the default branch on each repository
+        description: The branch to sync across all dependant repositories. Defaults to the default branch on each repository
         required: false
       toolchain:
         type: string
-        description: The rust toolchain to use. Defaults to 1.93.0
+        description: The rust toolchain to use. Defaults to rust-toolchain.toml's channel value
         required: false
 
 defaults:
@@ -82,18 +82,23 @@ jobs:
           submodules: true
           token: ${{ secrets.BOT_TOKEN_WORKFLOW }}
 
+      - id: toolchain
+        name: Get Rust toolchain
+        run: |
+          echo "rust-toolchain=$(cat rust-toolchain.toml | grep channel | cut -d'"' -f2)" >> $GITHUB_OUTPUT
+
       - name: Install Rust toolchain
         # NOTE: Showing the active Rust toolchain (defined by the rust-toolchain.toml file)
         # will have the side effect of installing it; if it's not installed already.
         run: |
-          rustup update ${{ inputs.toolchain || '1.93.0' }}
-          rustup component add --toolchain ${{ inputs.toolchain || '1.93.0'}} clippy
 
       # cyclors does not compile with cmake 4
       - name: Install cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: "3.31.x"
+          rustup update ${{ inputs.toolchain || steps.toolchain.outputs.rust-toolchain }}
+          rustup component add --toolchain ${{ inputs.toolchain || steps.toolchain.outputs.rust-toolchain }} clippy
 
       - name: Install build dependencies
         run: sudo apt-get install -y llvm-dev libclang-dev clang libacl1-dev
@@ -128,21 +133,21 @@ jobs:
       - name: Rectify lockfile
         # NOTE: Checking the package for errors will rectify the Cargo.lock while preserving
         # the dependency versions fetched from source.
-        run: cargo +${{ inputs.toolchain || '1.93.0' }} clippy --manifest-path ${{ steps.crate-path.outputs.value }}/Cargo.toml  --all-targets ${{ steps.clippy-options.outputs.value }} -- --deny warnings
+        run: cargo +${{ inputs.toolchain || steps.toolchain.outputs.rust-toolchain }} clippy --manifest-path ${{ steps.crate-path.outputs.value }}/Cargo.toml  --all-targets ${{ steps.clippy-options.outputs.value }} -- --deny warnings
 
       - name: Rectify lockfile for zenoh-c opaque-types
         if: ${{ matrix.dependant == 'eclipse-zenoh/zenoh-c' }}
         # Disable panic feature for zenoh-c opaque-types
         run: |
           features=$(cargo tree --manifest-path build-resources/opaque-types/Cargo.toml -f "{p} {f}" --all-features| grep opaque-types | cut -d" " -f4 | sed s/panic,//)
-          cargo +${{ inputs.toolchain || '1.93.0' }} clippy --manifest-path build-resources/opaque-types/Cargo.toml --all-targets --features $features -- --deny warnings
+          cargo +${{ inputs.toolchain || steps.toolchain.outputs.rust-toolchain }} clippy --manifest-path build-resources/opaque-types/Cargo.toml --all-targets --features $features -- --deny warnings
 
       - name: cargo update ${{ matrix.dependant }}
-        run: cargo +${{ inputs.toolchain || '1.93.0' }} update zenoh --manifest-path ${{ steps.crate-path.outputs.value }}/Cargo.toml
+        run: cargo +${{ inputs.toolchain || steps.toolchain.outputs.rust-toolchain }} update zenoh --manifest-path ${{ steps.crate-path.outputs.value }}/Cargo.toml
 
       - name: cargo update for zenoh-c build-resources
         if: ${{ matrix.dependant == 'eclipse-zenoh/zenoh-c' }}
-        run: cargo +${{ inputs.toolchain || '1.93.0' }} update zenoh --manifest-path build-resources/opaque-types/Cargo.toml
+        run: cargo +${{ inputs.toolchain || steps.toolchain.outputs.rust-toolchain }} update zenoh --manifest-path build-resources/opaque-types/Cargo.toml
 
       - name: Create/Update a pull request if the lockfile changed
         id: cpr

--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -91,12 +91,6 @@ jobs:
         # NOTE: Showing the active Rust toolchain (defined by the rust-toolchain.toml file)
         # will have the side effect of installing it; if it's not installed already.
         run: |
-
-      # cyclors does not compile with cmake 4
-      - name: Install cmake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: "3.31.x"
           rustup update ${{ inputs.toolchain || steps.toolchain.outputs.rust-toolchain }}
           rustup component add --toolchain ${{ inputs.toolchain || steps.toolchain.outputs.rust-toolchain }} clippy
 


### PR DESCRIPTION
Default to rust-toolchain.toml channel value when no input is provided while still allowing it to be overridden by an input.

Additionally update and pin the actions used in this workflow to their latest versions SHA and remove cmake install step as that's no longer necessary.

Fix failure syncing the lockfile to zenoh-backend-s3: https://github.com/eclipse-zenoh/zenoh/actions/runs/29555971459/job/87815036942