### PR TITLE
fix: always run cargo check after bumping

### DIFF
--- a/dist/bump-crates-main.mjs
+++ b/dist/bump-crates-main.mjs
@@ -68222,13 +68222,13 @@ async function main(input) {
           );
         }
       }
-      sh(`cargo +${input.toolchain} check`, { cwd: repo });
-      sh("git commit Cargo.lock --message 'chore: Update Cargo lockfile'", {
-        cwd: repo,
-        env: gitEnv,
-        check: false
-      });
     }
+    sh(`cargo +${input.toolchain} check`, { cwd: repo });
+    sh("git commit Cargo.lock --message 'chore: Update Cargo lockfile'", {
+      cwd: repo,
+      env: gitEnv,
+      check: false
+    });
     sh(`git push --force ${remote} ${input.branch}`, { cwd: repo });
     if (input.liveRun) {
       const tag = input.tag === "" ? input.version : input.tag;

--- a/src/bump-crates.ts
+++ b/src/bump-crates.ts
@@ -104,14 +104,13 @@ export async function main(input: Input) {
           );
         }
       }
-
-      sh(`cargo +${input.toolchain} check`, { cwd: repo });
-      sh("git commit Cargo.lock --message 'chore: Update Cargo lockfile'", {
-        cwd: repo,
-        env: gitEnv,
-        check: false,
-      });
     }
+    sh(`cargo +${input.toolchain} check`, { cwd: repo });
+    sh("git commit Cargo.lock --message 'chore: Update Cargo lockfile'", {
+      cwd: repo,
+      env: gitEnv,
+      check: false,
+    });
 
     sh(`git push --force ${remote} ${input.branch}`, { cwd: repo });
 


### PR DESCRIPTION
- after cargo.bump() and cargo.bumpDependencies() if the lockfile changed it needs to be committed. As it was cargo check and the subsequent Cargo.lock commit would only get executed when cargo.bumpDependencies() bumps some dependency. During live-run releases this is true but during dry-run daily runs, cargo.bumpDependencies() is normally skipped.

Fix https://github.com/eclipse-zenoh/zenoh-backend-rocksdb/actions/runs/29790186602/job/88510082069