### PR TITLE
fix: remove default 1.93.0 toolchain

### DIFF
--- a/.github/workflows/recreate-lockfile.yml
+++ b/.github/workflows/recreate-lockfile.yml
@@ -11,7 +11,7 @@ on:
         required: false
       toolchain:
         type: string
-        description: The rust toolchain to use. Defaults to 1.93.0
+        description: The rust toolchain to use. Defaults to rust-toolchain.toml's channel value
         required: false
 
 defaults:
@@ -37,18 +37,32 @@ jobs:
           echo "head-hash=$(git log -1 --format=%h)" >> $GITHUB_OUTPUT
           echo "head-date=$(git log -1 --format=%as)" >> $GITHUB_OUTPUT
 
+      - id: toolchain
+        name: Get Rust toolchain
+        env:
+          TOOLCHAIN_INPUT: ${{ inputs.toolchain }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "$TOOLCHAIN_INPUT" ]]; then
+            RUST_TOOLCHAIN="$TOOLCHAIN_INPUT"
+          else
+            RUST_TOOLCHAIN="$(yq -r '.toolchain.channel // ""' rust-toolchain.toml)"
+          fi
+
+          if [[ ! "$RUST_TOOLCHAIN" =~ ^[A-Za-z0-9][A-Za-z0-9._+@-]*$ ]]; then
+            echo "Invalid Rust toolchain" >&2
+            exit 1
+          fi
+
+          printf 'RUST_TOOLCHAIN=%s\n' "$RUST_TOOLCHAIN" >> "$GITHUB_ENV"
+
       - name: Install Rust toolchain
         # NOTE: Showing the active Rust toolchain (defined by the rust-toolchain.toml file)
         # will have the side effect of installing it; if it's not installed already.
         run: |
-          rustup update ${{ inputs.toolchain || '1.93.0' }}
-          rustup component add --toolchain ${{ inputs.toolchain || '1.93.0'}} clippy
-
-      # cyclors does not compile with cmake 4
-      - name: Install cmake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: "3.31.x"
+          rustup update "$RUST_TOOLCHAIN"
+          rustup component add --toolchain "$RUST_TOOLCHAIN" clippy
 
       - name: Install build dependencies
         run: sudo apt-get install -y llvm-dev libclang-dev clang libacl1-dev
@@ -56,7 +70,7 @@ jobs:
       - name: Recreate Cargo.lock
         run: |
           rm -f Cargo.lock
-          cargo +${{ inputs.toolchain || '1.93.0' }} update --manifest-path Cargo.toml
+          cargo "+${RUST_TOOLCHAIN}" update --manifest-path Cargo.toml
 
       - name: Create/Update a pull request if the lockfile changed
         id: cpr

--- a/dist/bump-crates-main.mjs
+++ b/dist/bump-crates-main.mjs
@@ -68160,7 +68160,7 @@ function setup() {
   const branch = getInput("branch", { required: true });
   const repo = getInput("repo", { required: true });
   const path12 = getInput("path");
-  const toolchain = getInput("toolchain");
+  const toolchain = getInput("toolchain", { required: false });
   const tag = getInput("tag", { required: false });
   const githubToken = getInput("github-token", { required: true });
   const bumpDepsBranch = getInput("bump-deps-branch");
@@ -68186,7 +68186,7 @@ function setup() {
     branch,
     repo,
     path: path12 === "" ? void 0 : path12,
-    toolchain: toolchain === "" ? "1.93.0" : toolchain,
+    toolchain: toolchain === "" ? "" : `+${toolchain}`,
     tag,
     githubToken,
     bumpDepsPattern,
@@ -68223,7 +68223,7 @@ async function main(input) {
         }
       }
     }
-    sh(`cargo +${input.toolchain} check`, { cwd: repo });
+    sh(`cargo ${input.toolchain} check`, { cwd: repo });
     sh("git commit Cargo.lock --message 'chore: Update Cargo lockfile'", {
       cwd: repo,
       env: gitEnv,

--- a/dist/set-git-branch-main.mjs
+++ b/dist/set-git-branch-main.mjs
@@ -68082,7 +68082,7 @@ function setup() {
   const releaseBranch = getInput("release-branch", { required: true });
   const repo = getInput("repo", { required: true });
   const path12 = getInput("path");
-  const toolchain = getInput("toolchain");
+  const toolchain = getInput("toolchain", { required: false });
   const githubToken = getInput("github-token", { required: true });
   const githubUser = getInput("github-user");
   const depsPattern = getInput("deps-pattern");
@@ -68093,7 +68093,7 @@ function setup() {
     releaseBranch,
     repo,
     path: path12 === "" ? void 0 : path12,
-    toolchain: toolchain === "" ? "1.93.0" : toolchain,
+    toolchain: toolchain === "" ? "" : `+${toolchain}`,
     githubToken,
     githubUser: githubUser === "" ? "eclipse-zenoh-bot" : githubUser,
     depsRegExp: depsPattern === "" ? void 0 : new RegExp(depsPattern),
@@ -68123,7 +68123,7 @@ async function main(input) {
       }
     }
     for (path12 of pathsToCheck) {
-      sh(`cargo +${input.toolchain} check -vv --manifest-path ../${path12}`, { cwd: repo, env: gitEnv });
+      sh(`cargo ${input.toolchain} check -vv --manifest-path ../${path12}`, { cwd: repo, env: gitEnv });
       sh("find . -name 'Cargo.lock' | xargs git add", { cwd: repo });
       sh("git commit --message 'chore: Update Cargo lockfile'", {
         cwd: repo,

--- a/dist/set-registry-main.mjs
+++ b/dist/set-registry-main.mjs
@@ -68081,7 +68081,7 @@ function setup() {
   const releaseBranch = getInput("release-branch", { required: true });
   const repo = getInput("repo", { required: true });
   const path12 = getInput("path");
-  const toolchain = getInput("toolchain");
+  const toolchain = getInput("toolchain", { required: false });
   const githubToken = getInput("github-token", { required: true });
   const depsPattern = getInput("deps-pattern");
   return {
@@ -68093,7 +68093,7 @@ function setup() {
     releaseBranch,
     repo,
     path: path12 === "" ? void 0 : path12,
-    toolchain: toolchain === "" ? "1.93.0" : toolchain,
+    toolchain: toolchain === "" ? "" : `+${toolchain}`,
     githubToken,
     depsRegExp: depsPattern === "" ? new RegExp("$^") : new RegExp(depsPattern)
   };
@@ -68114,7 +68114,7 @@ async function main(input) {
     if (sh("git diff", { cwd: repo, check: false })) {
       sh("find . -name 'Cargo.toml*' | xargs git add", { cwd: repo });
       sh(`git commit --message 'chore: Update Cargo.toml to use ${input.registry}'`, { cwd: repo, env: gitEnv });
-      sh(`cargo +${input.toolchain} check`, { cwd: repo });
+      sh(`cargo ${input.toolchain} check`, { cwd: repo });
       sh("find . -name 'Cargo.lock' | xargs git add", { cwd: repo });
       sh("git commit --message 'chore: Update Cargo lockfile'", {
         cwd: repo,

--- a/src/bump-crates.ts
+++ b/src/bump-crates.ts
@@ -13,7 +13,7 @@ export type Input = {
   branch: string;
   repo: string;
   path?: string;
-  toolchain?: string;
+  toolchain: string;
   tag?: string;
   githubToken: string;
   bumpDepsPattern?: RegExp[];
@@ -27,7 +27,7 @@ export function setup(): Input {
   const branch = core.getInput("branch", { required: true });
   const repo = core.getInput("repo", { required: true });
   const path = core.getInput("path");
-  const toolchain = core.getInput("toolchain");
+  const toolchain = core.getInput("toolchain", { required: false });
   const tag = core.getInput("tag", { required: false });
   const githubToken = core.getInput("github-token", { required: true });
   const bumpDepsBranch = core.getInput("bump-deps-branch");
@@ -59,7 +59,7 @@ export function setup(): Input {
     branch,
     repo,
     path: path === "" ? undefined : path,
-    toolchain: toolchain === "" ? "1.93.0" : toolchain,
+    toolchain: toolchain === "" ? "" : `+${toolchain}`,
     tag,
     githubToken,
     bumpDepsPattern,
@@ -105,7 +105,7 @@ export async function main(input: Input) {
         }
       }
     }
-    sh(`cargo +${input.toolchain} check`, { cwd: repo });
+    sh(`cargo ${input.toolchain} check`, { cwd: repo });
     sh("git commit Cargo.lock --message 'chore: Update Cargo lockfile'", {
       cwd: repo,
       env: gitEnv,

--- a/src/set-git-branch.ts
+++ b/src/set-git-branch.ts
@@ -12,7 +12,7 @@ export type Input = {
   releaseBranch: string;
   repo: string;
   path?: string;
-  toolchain?: string;
+  toolchain: string;
   githubToken: string;
   githubUser?: string;
   depsRegExp: RegExp;
@@ -25,7 +25,7 @@ export function setup(): Input {
   const releaseBranch = core.getInput("release-branch", { required: true });
   const repo = core.getInput("repo", { required: true });
   const path = core.getInput("path");
-  const toolchain = core.getInput("toolchain");
+  const toolchain = core.getInput("toolchain", { required: false });
   const githubToken = core.getInput("github-token", { required: true });
   const githubUser = core.getInput("github-user");
   const depsPattern = core.getInput("deps-pattern");
@@ -37,7 +37,7 @@ export function setup(): Input {
     releaseBranch,
     repo,
     path: path === "" ? undefined : path,
-    toolchain: toolchain === "" ? "1.93.0" : toolchain,
+    toolchain: toolchain === "" ? "" : `+${toolchain}`,
     githubToken,
     githubUser: githubUser === "" ? "eclipse-zenoh-bot" : githubUser,
     depsRegExp: depsPattern === "" ? undefined : new RegExp(depsPattern),
@@ -76,7 +76,7 @@ export async function main(input: Input) {
     for (path of pathsToCheck) {
       // cargo check fails if not executed from the directory containing Cargo.toml even when using --manifest-path
       // so we pass cwd as the repo root and use ../ in the manifest-path
-      sh(`cargo +${input.toolchain} check -vv --manifest-path ../${path}`, { cwd: repo, env: gitEnv });
+      sh(`cargo ${input.toolchain} check -vv --manifest-path ../${path}`, { cwd: repo, env: gitEnv });
       sh("find . -name 'Cargo.lock' | xargs git add", { cwd: repo });
       sh("git commit --message 'chore: Update Cargo lockfile'", {
         cwd: repo,

--- a/src/set-registry.ts
+++ b/src/set-registry.ts
@@ -16,7 +16,7 @@ export type Input = {
   releaseBranch: string;
   repo: string;
   path?: string;
-  toolchain?: string;
+  toolchain: string;
   githubToken: string;
   depsRegExp: RegExp;
 };
@@ -30,7 +30,7 @@ export function setup(): Input {
   const releaseBranch = core.getInput("release-branch", { required: true });
   const repo = core.getInput("repo", { required: true });
   const path = core.getInput("path");
-  const toolchain = core.getInput("toolchain");
+  const toolchain = core.getInput("toolchain", { required: false });
   const githubToken = core.getInput("github-token", { required: true });
   const depsPattern = core.getInput("deps-pattern");
 
@@ -43,7 +43,7 @@ export function setup(): Input {
     releaseBranch,
     repo,
     path: path === "" ? undefined : path,
-    toolchain: toolchain === "" ? "1.93.0" : toolchain,
+    toolchain: toolchain === "" ? "" : `+${toolchain}`,
     githubToken,
     depsRegExp: depsPattern === "" ? new RegExp("$^") : new RegExp(depsPattern),
   };
@@ -69,7 +69,7 @@ export async function main(input: Input) {
       sh("find . -name 'Cargo.toml*' | xargs git add", { cwd: repo });
       sh(`git commit --message 'chore: Update Cargo.toml to use ${input.registry}'`, { cwd: repo, env: gitEnv });
 
-      sh(`cargo +${input.toolchain} check`, { cwd: repo });
+      sh(`cargo ${input.toolchain} check`, { cwd: repo });
       sh("find . -name 'Cargo.lock' | xargs git add", { cwd: repo });
       sh("git commit --message 'chore: Update Cargo lockfile'", {
         cwd: repo,


### PR DESCRIPTION
- zenoh repos using the actions defined here already have rust-toolchain.toml in the root of the repo, prefer using the repo default but still allowing an override
- cleanup recreate-lockfile.yml to remove unnecessary cmake install

Fix release workflows:
 - https://github.com/eclipse-zenoh/zenoh-backend-s3/actions/runs/30410702722/job/90445879786
 - https://github.com/eclipse-zenoh/zenoh-dissector/actions/runs/30410806867/job/90446206967