### PR TITLE
chore: run apt-get update before install

### DIFF
--- a/.github/workflows/release-crates-cargo.yml
+++ b/.github/workflows/release-crates-cargo.yml
@@ -60,7 +60,7 @@ jobs:
           swap-storage: true
 
       - name: Install build-essential (Ubuntu)
-        run: sudo apt-get install -y build-essential clang libc6-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential clang libc6-dev
 
       - uses: eclipse-zenoh/ci/publish-crates-cargo@main
         with:


### PR DESCRIPTION
Run apt-get update before install after disk cleanup

Fix:
- https://github.com/eclipse-zenoh/zenoh-ts/actions/runs/30503318309/job/90749303060
- https://github.com/eclipse-zenoh/zenoh-plugin-webserver/actions/runs/30503086880/job/90832765025
- https://github.com/eclipse-zenoh/zenoh-plugin-mqtt/actions/runs/30503176744/job/90832873915
- https://github.com/eclipse-zenoh/zenoh-plugin-dds/actions/runs/30502835197
- https://github.com/eclipse-zenoh/zenoh-backend-s3/actions/runs/30502274207/job/90832992772
- https://github.com/eclipse-zenoh/zenoh-backend-rocksdb/actions/runs/30502504080/job/90833052568
- https://github.com/eclipse-zenoh/zenoh-backend-influxdb/actions/runs/30502306970
- https://github.com/eclipse-zenoh/zenoh-backend-filesystem/actions/runs/30502924579/job/90832525578
- https://github.com/eclipse-zenoh/zenoh/actions/runs/30502285056/job/90833025253