### PR TITLE
sync-lockfiles: support the rebuilt zenoh-java/zenoh-kotlin (add zenoh-flat, zenoh-flat-jni; drop the crate-path special case)

### DIFF
--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -64,6 +64,8 @@ jobs:
           - eclipse-zenoh/zenoh-python
           - eclipse-zenoh/zenoh-java
           - eclipse-zenoh/zenoh-kotlin
+          - eclipse-zenoh/zenoh-flat
+          - eclipse-zenoh/zenoh-flat-jni
           - eclipse-zenoh/zenoh-plugin-dds
           - eclipse-zenoh/zenoh-plugin-mqtt
           - eclipse-zenoh/zenoh-plugin-ros2dds

--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -114,18 +114,6 @@ jobs:
       - name: Install build dependencies
         run: sudo apt-get install -y llvm-dev libclang-dev clang libacl1-dev
 
-      # NOTE: Not all Zenoh dependants have their Cargo manifest and lockfile
-      # at the repository's toplevel. The only exception being zenoh-kotlin and
-      # zenoh-java. Thus the need for this ugly workaround.
-      - name: Compute crate path of ${{ matrix.dependant }}
-        id: crate-path
-        run: |
-          if [[ "${{ matrix.dependant }}" =~ eclipse-zenoh/zenoh-(java|kotlin) ]]; then
-            echo "value=zenoh-jni" >> $GITHUB_OUTPUT
-          else
-            echo "value=." >> $GITHUB_OUTPUT
-          fi
-
       - name: Compute clippy options
         id: clippy-options
         run: |
@@ -139,12 +127,12 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Cargo.lock
-          path: ${{ steps.crate-path.outputs.value }}
+          path: .
 
       - name: Rectify lockfile
         # NOTE: Checking the package for errors will rectify the Cargo.lock while preserving
         # the dependency versions fetched from source.
-        run: cargo "+${RUST_TOOLCHAIN}" clippy --manifest-path ${{ steps.crate-path.outputs.value }}/Cargo.toml  --all-targets ${{ steps.clippy-options.outputs.value }} -- --deny warnings
+        run: cargo "+${RUST_TOOLCHAIN}" clippy --manifest-path Cargo.toml --all-targets ${{ steps.clippy-options.outputs.value }} -- --deny warnings
 
       - name: Rectify lockfile for zenoh-c opaque-types
         if: ${{ matrix.dependant == 'eclipse-zenoh/zenoh-c' }}
@@ -154,7 +142,7 @@ jobs:
           cargo "+${RUST_TOOLCHAIN}" clippy --manifest-path build-resources/opaque-types/Cargo.toml --all-targets --features $features -- --deny warnings
 
       - name: cargo update ${{ matrix.dependant }}
-        run: cargo "+${RUST_TOOLCHAIN}" update zenoh --manifest-path ${{ steps.crate-path.outputs.value }}/Cargo.toml
+        run: cargo "+${RUST_TOOLCHAIN}" update zenoh --manifest-path Cargo.toml
 
       - name: cargo update for zenoh-c build-resources
         if: ${{ matrix.dependant == 'eclipse-zenoh/zenoh-c' }}


### PR DESCRIPTION
Everything `sync-lockfiles` needs for the rebuilt zenoh-java / zenoh-kotlin, in
five changed lines: two new dependants, and the removal of the special case that
existed for the two old ones.

```diff
   - eclipse-zenoh/zenoh-kotlin
+  - eclipse-zenoh/zenoh-flat
+  - eclipse-zenoh/zenoh-flat-jni
```
```diff
-      - name: Compute crate path of ${{ matrix.dependant }}
-        run: |
-          if [[ "${{ matrix.dependant }}" =~ eclipse-zenoh/zenoh-(java|kotlin) ]]; then
-            echo "value=zenoh-jni" >> $GITHUB_OUTPUT
...
-          path: ${{ steps.crate-path.outputs.value }}
+          path: .
```

## Background: what changed in the SDKs

zenoh-java and zenoh-kotlin no longer contain a Rust JNI crate. Their bindings
are generated from a single annotated Rust surface and shipped as a separate
library:

```text
zenoh ──> zenoh-flat ──> zenoh-flat-jni ──> zenoh-java
                                        └─> zenoh-kotlin
```

- **`zenoh-flat`** — the annotated Rust surface multi-language bindings are
  generated from. Depends on `zenoh` / `zenoh-ext` in the usual `version` +
  `git` + `branch = "main"` shape.
- **`zenoh-flat-jni`** — the JNI/Kotlin binding generated from it, published as
  `org.eclipse.zenoh:zenoh-flat-jni`. Depends on `zenoh`, `zenoh-ext` and
  `zenoh-flat`.

Both commit a `Cargo.lock` and carry a `rust-toolchain.toml` (`channel =
"1.97.1"`, matching zenoh), which is what this workflow needs from a dependant.
They are two more zenoh bindings that have to stay ABI-aligned with zenoh, and
today nothing keeps them aligned.

## Why the crate-path step goes

It exists for exactly two repositories — the `zenoh-(java|kotlin) → zenoh-jni`
branch above — and **`zenoh-jni/` no longer exists in either of them** (merged
2026-08-10: eclipse-zenoh/zenoh-java#482, eclipse-zenoh/zenoh-kotlin#669). The
last sync run predates that, so the next run — the next push to zenoh’s `main`
touching its `Cargo.lock` — points both jobs at a
manifest that is gone. This PR is what restores them, not a cleanup.

What each SDK keeps instead is a manifest at the repository **root**, whose
lockfile records the `zenoh-flat-jni` commit its CI builds against:

```toml
# zenoh-kotlin/Cargo.toml — a pin crate, compiles to nothing anyone ships
[dependencies]
zenoh-flat-jni = { git = "https://github.com/eclipse-zenoh/zenoh-flat-jni.git", branch = "main" }
```
```text
Cargo.lock:  source = "git+https://github.com/eclipse-zenoh/zenoh-flat-jni.git?branch=main#<40-hex commit>"
```

That commit is the pin their Gradle build reads and checks out, and this workflow
already knows how to move it, with no new step: overwrite the lockfile with
zenoh's — which carries no `zenoh-flat-jni` entry, so the pin is *removed* —
rectify by resolving again, which writes the current commit back and compiles it.
Same sync, same auto-merging pull request, no special casing. The SDKs chose a
lockfile as their pin precisely so that this workflow, unmodified, is what keeps
them current.

With no dependant left below the toplevel, the step, its `if`, and the three
interpolations of its output all go. zenoh-c's `build-resources/opaque-types`
steps are unaffected — they always named their manifest explicitly.

## Two things I expected to need, and verified are not needed

**A crate path for the new entries.** Both keep their manifest at the root, so
the default `.` is right. The old special case did not false-match them either —
the pattern needs `zenoh-` immediately followed by `java`/`kotlin`, and
`zenoh-flat-jni` has `flat-jni` there:

```text
eclipse-zenoh/zenoh-flat-jni  -> .
eclipse-zenoh/zenoh-flat      -> .
```

**A `cargo update zenoh-flat` step.** `zenoh-flat-jni` is the first *two-level*
dependant here — it reaches zenoh both directly and through `zenoh-flat` — so I
expected the hardcoded `cargo update zenoh` to leave the intermediate crate
stale. It does not, and the reason is structural: zenoh's lockfile has no
`zenoh-flat` entry at all, so overwriting the dependant's lock with it *removes*
that pin, and the rectify step then resolves the git dependency fresh from
`branch = "main"`. Ran the full sequence locally against zenoh's real
`Cargo.lock` to confirm:

```text
zenoh Cargo.lock contains zenoh-flat:  no
after overwrite + rectify:
  zenoh-flat -> git+…/zenoh-flat.git?branch=main#86cfb75   (= zenoh-flat main HEAD)
  cc         -> 1.4.0                                      (= zenoh's pin, preserved)
```

So the intermediate crate refreshes on every sync for free, and zenoh's pins
survive — which is the property the sync exists for. An explicit update step
would have been dead weight. The same argument is what makes the SDK pin work:
`zenoh-flat-jni` is absent from zenoh's lockfile for exactly the same reason.

## Verifying

`workflow_dispatch` on this branch and check the `zenoh-flat`, `zenoh-flat-jni`,
`zenoh-java` and `zenoh-kotlin` jobs. Each should open a lockfile pull request
against its dependant. `fail-fast: false` already keeps one dependant's failure
off the others, and nothing outside those four jobs is touched.

The crate-path removal needs the root manifest on each SDK's default branch —
eclipse-zenoh/zenoh-kotlin#700 and eclipse-zenoh/zenoh-java#521. Until those
land, the two SDK jobs fail on a missing root `Cargo.toml` rather than on the
missing `zenoh-jni/Cargo.toml` they hit today.
