### PR TITLE
sync-lockfiles: every dependant keeps its manifest at the toplevel

### DIFF
--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -112,18 +112,6 @@ jobs:
       - name: Install build dependencies
         run: sudo apt-get install -y llvm-dev libclang-dev clang libacl1-dev
 
-      # NOTE: Not all Zenoh dependants have their Cargo manifest and lockfile
-      # at the repository's toplevel. The only exception being zenoh-kotlin and
-      # zenoh-java. Thus the need for this ugly workaround.
-      - name: Compute crate path of ${{ matrix.dependant }}
-        id: crate-path
-        run: |
-          if [[ "${{ matrix.dependant }}" =~ eclipse-zenoh/zenoh-(java|kotlin) ]]; then
-            echo "value=zenoh-jni" >> $GITHUB_OUTPUT
-          else
-            echo "value=." >> $GITHUB_OUTPUT
-          fi
-
       - name: Compute clippy options
         id: clippy-options
         run: |
@@ -137,12 +125,12 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Cargo.lock
-          path: ${{ steps.crate-path.outputs.value }}
+          path: .
 
       - name: Rectify lockfile
         # NOTE: Checking the package for errors will rectify the Cargo.lock while preserving
         # the dependency versions fetched from source.
-        run: cargo "+${RUST_TOOLCHAIN}" clippy --manifest-path ${{ steps.crate-path.outputs.value }}/Cargo.toml  --all-targets ${{ steps.clippy-options.outputs.value }} -- --deny warnings
+        run: cargo "+${RUST_TOOLCHAIN}" clippy --manifest-path Cargo.toml --all-targets ${{ steps.clippy-options.outputs.value }} -- --deny warnings
 
       - name: Rectify lockfile for zenoh-c opaque-types
         if: ${{ matrix.dependant == 'eclipse-zenoh/zenoh-c' }}
@@ -152,7 +140,7 @@ jobs:
           cargo "+${RUST_TOOLCHAIN}" clippy --manifest-path build-resources/opaque-types/Cargo.toml --all-targets --features $features -- --deny warnings
 
       - name: cargo update ${{ matrix.dependant }}
-        run: cargo "+${RUST_TOOLCHAIN}" update zenoh --manifest-path ${{ steps.crate-path.outputs.value }}/Cargo.toml
+        run: cargo "+${RUST_TOOLCHAIN}" update zenoh --manifest-path Cargo.toml
 
       - name: cargo update for zenoh-c build-resources
         if: ${{ matrix.dependant == 'eclipse-zenoh/zenoh-c' }}


### PR DESCRIPTION
The crate-path step exists for exactly two repositories — zenoh-java and
zenoh-kotlin, whose Cargo manifest lived under `zenoh-jni/`. Both are being
rebuilt on the generated `zenoh-flat-jni` bindings (eclipse-zenoh/zenoh-java#482,
eclipse-zenoh/zenoh-kotlin#669) and no longer contain that crate at all.

They are not leaving this workflow, though. What each keeps is a manifest at the
repository **root**, whose lockfile records the `zenoh-flat-jni` commit its CI
builds against:

```toml
# zenoh-kotlin/Cargo.toml — compiles to nothing anyone ships
[dependencies]
zenoh-flat-jni = { git = "https://github.com/eclipse-zenoh/zenoh-flat-jni.git", branch = "main" }
```

```text
Cargo.lock:  source = "git+https://github.com/eclipse-zenoh/zenoh-flat-jni.git?branch=main#<40-hex commit>"
```

That is the pin their CI reads, and this workflow already knows how to move it:
overwrite the lockfile with zenoh's — which carries no `zenoh-flat-jni` entry, so
the pin is removed — rectify by resolving again, which writes back the current
commit and compiles it. Same sync, same auto-merging pull request, no special
casing. Rehearsed against the real zenoh lockfile before proposing this: the
rectify step compiled clean in under a minute and the pin came back pointing at
zenoh-flat-jni's `main` tip.

With no dependant left below the toplevel, the step, its `if` and the three
interpolations of its output all go. zenoh-c's `build-resources/opaque-types`
steps are unaffected — they always named their manifest explicitly.

### Ordering

Merge after both SDKs have their root manifest **on the branch this workflow
syncs**, i.e. their default branch:

| | root manifest on `main`? |
| --- | --- |
| zenoh-kotlin | eclipse-zenoh/zenoh-kotlin#700, open, CI green |
| zenoh-java | after eclipse-zenoh/zenoh-java#482 lands, with the same crate |

Until then zenoh-java still keeps its manifest under `zenoh-jni/`, and this would
point its sync at a path that does not exist. Unrelated to eclipse-zenoh/ci#465,
which only adds `zenoh-flat` and `zenoh-flat-jni` to the matrix and can merge
whenever.
